### PR TITLE
docs: add new items, events & payment documentation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -576,6 +576,102 @@
         {
             "source": "/zones",
             "destination": "/v2/zones"
+        },
+        {
+            "source": "/addons/stripe",
+            "destination": "/v2/addons/stripe"
+        },
+        {
+            "source": "/cart",
+            "destination": "/v2/cart"
+        },
+        {
+            "source": "/demo-store",
+            "destination": "/v2/demo-store"
+        },
+        {
+            "source": "/events",
+            "destination": "/v2/events"
+        },
+        {
+            "source": "/fulfillment",
+            "destination": "/v2/fulfillment"
+        },
+        {
+            "source": "/payment-methods",
+            "destination": "/v2/payment-methods"
+        },
+        {
+            "source": "/payments",
+            "destination": "/v2/payments"
+        },
+        {
+            "source": "/product-tags",
+            "destination": "/v2/product-tags"
+        },
+        {
+            "source": "/reference/typescript-types",
+            "destination": "/v2/reference/typescript-types"
+        },
+        {
+            "source": "/reference/types/catalog",
+            "destination": "/v2/reference/types/catalog"
+        },
+        {
+            "source": "/reference/types/customer",
+            "destination": "/v2/reference/types/customer"
+        },
+        {
+            "source": "/reference/types/order",
+            "destination": "/v2/reference/types/order"
+        },
+        {
+            "source": "/reference/types/product",
+            "destination": "/v2/reference/types/product"
+        },
+        {
+            "source": "/suppliers",
+            "destination": "/v2/suppliers"
+        },
+        {
+            "source": "/upgrade/v2-1-to-v2-2",
+            "destination": "/v2/upgrade/v2-1-to-v2-2"
+        },
+        {
+            "source": "/upgrade/v2-2-to-v2-3",
+            "destination": "/v2/upgrade/v2-2-to-v2-3"
+        },
+        {
+            "source": "/upgrade/v2-4-to-v2-5",
+            "destination": "/v2/upgrade/v2-4-to-v2-5"
+        },
+        {
+            "source": "/user-guide/catalog/products/creating-product",
+            "destination": "/v2/user-guide/catalog/products/creating-product"
+        },
+        {
+            "source": "/user-guide/catalog/products/external-product",
+            "destination": "/v2/user-guide/catalog/products/external-product"
+        },
+        {
+            "source": "/user-guide/catalog/products/managing-products",
+            "destination": "/v2/user-guide/catalog/products/managing-products"
+        },
+        {
+            "source": "/user-guide/catalog/products/overview",
+            "destination": "/v2/user-guide/catalog/products/overview"
+        },
+        {
+            "source": "/user-guide/catalog/products/standard-product",
+            "destination": "/v2/user-guide/catalog/products/standard-product"
+        },
+        {
+            "source": "/user-guide/catalog/products/variant-product",
+            "destination": "/v2/user-guide/catalog/products/variant-product"
+        },
+        {
+            "source": "/user-guide/catalog/products/virtual-product",
+            "destination": "/v2/user-guide/catalog/products/virtual-product"
         }
     ],
     "seo": {

--- a/docs.json
+++ b/docs.json
@@ -194,6 +194,7 @@
                   "group": "Sales",
                   "pages": [
                     "v2/customers",
+                    "v2/cart",
                     "v2/orders",
                     "v2/payments",
                     "v2/fulfillment"

--- a/docs.json
+++ b/docs.json
@@ -162,6 +162,7 @@
                       "group": "Upgrade Guide",
                       "pages": [
                         "v2/upgrade",
+                        "v2/upgrade/v2-5-to-v2-6",
                         "v2/upgrade/v2-4-to-v2-5",
                         "v2/upgrade/v2-2-to-v2-3",
                         "v2/upgrade/v2-1-to-v2-2"
@@ -175,7 +176,8 @@
                   "pages": [
                     "v2/requirements",
                     "v2/installation",
-                    "v2/configuration"
+                    "v2/configuration",
+                    "v2/dashboard"
                   ]
                 },
                 {
@@ -197,7 +199,8 @@
                     "v2/cart",
                     "v2/orders",
                     "v2/payments",
-                    "v2/fulfillment"
+                    "v2/fulfillment",
+                    "v2/taxes"
                   ]
                 },
                 {
@@ -245,7 +248,9 @@
                     "v2/extending/overview",
                     "v2/extending/control-panel",
                     "v2/extending/navigation",
-                    "v2/extending/controllers"
+                    "v2/extending/controllers",
+                    "v2/render-hooks",
+                    "v2/addons"
                   ]
                 },
                 {

--- a/favicon.svg
+++ b/favicon.svg
@@ -1,5 +1,5 @@
 <svg height="145" viewBox="0 0 120 145" width="120" xmlns="http://www.w3.org/2000/svg">
-    <title>Laravel Shopper Logomark</title>
+    <title>Shopper Logomark</title>
     <radialGradient id="a" cx="105" cy="40" gradientUnits="userSpaceOnUse" r="135">
         <stop offset="0" stop-color="#60a5fa"/>
         <stop offset="1" stop-color="#2563eb"/>

--- a/logo/logo.svg
+++ b/logo/logo.svg
@@ -1,5 +1,5 @@
 <svg height="145" viewBox="0 0 120 145" width="120" xmlns="http://www.w3.org/2000/svg">
-    <title>Laravel Shopper Logomark</title>
+    <title>Shopper Logomark</title>
     <radialGradient id="a" cx="105" cy="40" gradientUnits="userSpaceOnUse" r="135">
         <stop offset="0" stop-color="#60a5fa"/>
         <stop offset="1" stop-color="#2563eb"/>

--- a/v1/configuration.mdx
+++ b/v1/configuration.mdx
@@ -118,9 +118,9 @@ Shopper gives you the ability to add middleware to all of your routes. These mid
 By default none of your routes in the `web.php` file will be accessible and loaded in the shopper administration. So that your routes added in the sidebar can have the middleware applied to the dashboard, you must fill in an additional routing file and this will be automatically loaded by Shopper's internal RouteServiceProvider.
 
 ## Components
-The main features of Laravel Shopper is to handle Livewire components to add new functionnalities to your admin panel.
+The main features of Shopper is to handle Livewire components to add new functionnalities to your admin panel.
 
-For this purpose you have a component file that lists all Livewire components used within Laravel Shopper. You can for each feature modify the associated or extends component to add functionality or even change the view to fit your own logic.
+For this purpose you have a component file that lists all Livewire components used within Shopper. You can for each feature modify the associated or extends component to add functionality or even change the view to fit your own logic.
 
 Here is an example of some components
 

--- a/v1/customization.mdx
+++ b/v1/customization.mdx
@@ -7,7 +7,7 @@ description:
   This is documentation for Shopper v1, which is no longer maintained. Please refer to the [v2 docs](/v2) for the latest information.
 </Warning>
 
-Once you have installed Shopper, you need to set up a store to serve as your first location.  After creating a new user, you need to login via the url `/shopper/login`. After logging in you need to fill in the required information to access the Laravel Shopper dashboard
+Once you have installed Shopper, you need to set up a store to serve as your first location.  After creating a new user, you need to login via the url `/shopper/login`. After logging in you need to fill in the required information to access the Shopper dashboard
 
 <Frame caption="Store customization">
   <img src="/images/v1/customization.png" alt="Shopper Config Example" />
@@ -98,7 +98,7 @@ When shipping an order, the products to be delivered/shipped will start from thi
 
 You must fill in the address of your location. You can specify GPS coordinates if you want customers to be able to geolocate you on a map with this information.
 
-Laravel Shopper uses mapbox to display this map. To configure your map you can go to the [mapbox documentation](https://docs.mapbox.com/mapbox-gl-js/api/).
+Shopper uses mapbox to display this map. To configure your map you can go to the [mapbox documentation](https://docs.mapbox.com/mapbox-gl-js/api/).
 
 <Frame caption="Store with enable mapbox">
   <img src="/images/v1/customization-map.png" alt="Store location with mapbox" />
@@ -151,7 +151,7 @@ The keys registered in the database during this section: `shop_facebook_link`, `
 ## Update setting
 You can update your store information when needed, edit your store images, update the complete address, the legal name of your shop, etc.
 
-Laravel Shopper at the moment doesn't manage several currencies so you must select with what currency you will sell on your site.
+Shopper at the moment doesn't manage several currencies so you must select with what currency you will sell on your site.
 
 To edit your shop information, you must:
 

--- a/v1/dashboard.mdx
+++ b/v1/dashboard.mdx
@@ -10,7 +10,7 @@ description: "The dashboard is a user-customizable screen. One of Shopper's main
 ## Overview
 When you log into the control panel, you will be taken to the dashboard — a customizable screen dispatch with a Livewire component!
 
-Laravel Shopper is a free open-source e-commerce application based on the [TALL Stack](https://tallstack.dev) and aims to build an e-commerce administration using only [Livewire](https://laravel-livewire.com) components.
+Shopper is a free open-source e-commerce application based on the [TALL Stack](https://tallstack.dev) and aims to build an e-commerce administration using only [Livewire](https://laravel-livewire.com) components.
 
 The navigation at the left contains the available panels for everyday use:
 

--- a/v1/extending/control-panel.mdx
+++ b/v1/extending/control-panel.mdx
@@ -126,7 +126,7 @@ module.export = {
 
 After update (or not) the colors of your administration theme to reflect your brand. You'll probably want to change the logo to display
 
-By default, Laravel Shopper logo is used next to your application name in the administration panel.
+By default, Shopper logo is used next to your application name in the administration panel.
 
 You can choose between 2 options
 
@@ -154,7 +154,7 @@ The 2nd option is to create a resources/views/vendor/shopper/components/brand.bl
 </Info>
 
 ```html
-<img className="w-auto h-12" src="{{ asset('shopper/images/shopper-icon.svg') }}" alt="Laravel Shopper" />
+<img className="w-auto h-12" src="{{ asset('shopper/images/shopper-icon.svg') }}" alt="Shopper" />
 ```
 
 ## Adding control panel routes

--- a/v1/installation.mdx
+++ b/v1/installation.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Installation"
-description: "Quick start guide for installing and configuring Laravel Shopper on your existing Laravel App"
+description: "Quick start guide for installing and configuring Shopper on your existing Laravel App"
 ---
 
 <Warning>

--- a/v1/locations.mdx
+++ b/v1/locations.mdx
@@ -7,7 +7,7 @@ description:
   This is documentation for Shopper v1, which is no longer maintained. Please refer to the [v2 docs](/v2) for the latest information.
 </Warning>
 
-By default when you install Laravel Shopper for the first time you configure and create your shop, and this allows you to create a first location which will have the information you defined. This is the initial location in which all products will be stored.
+By default when you install Shopper for the first time you configure and create your shop, and this allows you to create a first location which will have the information you defined. This is the initial location in which all products will be stored.
 
 If you have already used [Shopify](https://shopify.com) it is a bit the same model, but a little simpler so that you can modify it because the system is accessible for any type of business.
 

--- a/v1/requirements.mdx
+++ b/v1/requirements.mdx
@@ -10,7 +10,7 @@ description:
 Shopper is a modern PHP application, built as a [Laravel](https://laravel.com) package, and has the same server requirements as &mdash; you guessed it &mdash; Laravel itself. To manipulate images (resize, crop, etc), you will also need the GD Library or ImageMagick.
 
 ## Server Requirements
-To run Laravel Shopper you'll need a server meeting the following requirements. These are all pretty standard in most modern hosting platforms.
+To run Shopper you'll need a server meeting the following requirements. These are all pretty standard in most modern hosting platforms.
 
 ## PHP Version
 - PHP 8.0+

--- a/v1/roles-permissions.mdx
+++ b/v1/roles-permissions.mdx
@@ -59,10 +59,10 @@ Permissions are associated with roles. Depending on the role that a member has, 
 
 All this management of roles and permissions is done using the [Laravel Permission](https://github.com/spatie/laravel-permission) package from [Spatie](https://spatie.be).
 
-At installation Laravel Shopper comes with 3 roles: **Administrator**, **Manager** and **User**, the user role cannot be modified from the administration interface because it is the role that will be assigned to any customer who will create his account on your shop.
+At installation Shopper comes with 3 roles: **Administrator**, **Manager** and **User**, the user role cannot be modified from the administration interface because it is the role that will be assigned to any customer who will create his account on your shop.
 
 ## RBAC ACL
-RBAC (Role Based Access Control) or ACL (Access Control Layer) is an approach to restricting system access for users using roles system, Laravel Shopper allow to define the level of access for each user. With roles a user can access menus, pages. It is important to know that one Administrator can have multiple roles assigned.
+RBAC (Role Based Access Control) or ACL (Access Control Layer) is an approach to restricting system access for users using roles system, Shopper allow to define the level of access for each user. With roles a user can access menus, pages. It is important to know that one Administrator can have multiple roles assigned.
 
 To view the roles and permissions management page, you must go to the `Settings > Staff & Permissions`
 
@@ -149,7 +149,7 @@ return [
 ```
 
 ## Manage Roles
-A Role is a set of permissions to perform certain operations within the system, which is assigned to a chosen Administrator. As said previously Laravel Shopper at installation comes with 3 roles but 2 are accessible in the administration panel.
+A Role is a set of permissions to perform certain operations within the system, which is assigned to a chosen Administrator. As said previously Shopper at installation comes with 3 roles but 2 are accessible in the administration panel.
 
 The user role does not appear, modifying it could lead to bugs on your store so it is not listed here.
 

--- a/v2/acl.mdx
+++ b/v2/acl.mdx
@@ -5,23 +5,15 @@ description: Manage user roles and permissions with Laravel Permission integrati
 
 Manage access and permissions of your users and members in your store. The entire system of roles and permissions in Shopper is implemented by the package
 [spatie/laravel-permission](https://github.com/spatie/laravel-permission). Because all permissions will be registered on Laravel's gate, you can test if a user
-has a permission with Laravel's default [can()](https://laravel.com/v2/11.x/authorization#via-blade-templates) function.
+has a permission with Laravel's default [can()](https://laravel.com/docs/authorization#via-blade-templates) function.
 
-To access dashboard, you need to have the role `administrator` this role can be found in the configuration file `config/shopper/core.php`.
+To access the dashboard, a user must have the `administrator` role. Role names are configured in `config/shopper/admin.php`:
 
 ```php
-/*
-|--------------------------------------------------------------------------
-| Configurations for the user
-|--------------------------------------------------------------------------
-|
-| User configuration to manage user access using spatie/laravel-permission.
-|
-*/
-
-'users' => [
-  'admin_role' => 'administrator',
-  'default_role' => 'user',
+'roles' => [
+    'admin'   => 'administrator',
+    'manager' => 'manager',
+    'user'    => 'user',
 ],
 ```
 
@@ -76,7 +68,7 @@ To view the roles and permissions management page, you must go to the **Settings
 
 ## Model
 
-The model used for the **Role** is `Shopper\Core\Models\Role` this model extend from the Spatie Role model.
+The model used for the **Role** is `Shopper\Models\Role` this model extend from the Spatie Role model.
 
 | Name             | Type    | Required | Notes                                                       |
 |------------------|---------|----------|-------------------------------------------------------------|
@@ -87,7 +79,7 @@ The model used for the **Role** is `Shopper\Core\Models\Role` this model extend 
 | `description`    | text    | no       | Nullable, the role description                              |
 | `can_be_removed` | boolean | no       | Default `true`, defines if a role can be deleted.           |
 
-And the **Permission** model is `Shopper\Core\Models\Permission`
+And the **Permission** model is `Shopper\Models\Permission`
 
 | Name             | Type    | Required | Notes                                                             |
 |------------------|---------|----------|-------------------------------------------------------------------|
@@ -102,30 +94,12 @@ And the **Permission** model is `Shopper\Core\Models\Permission`
 The **Permission** model has some groups as shown here
 
 ```php
-namespace Shopper\Core\Models\User;
+use Shopper\Models\Permission;
 
-use Spatie\Permission\Models\Permission as SpatiePermission;
-
-class Permission extends SpatiePermission
-{
-  /**
-   * Get a lists of permissions groups.
-   */
-  public static function groups(): array
-  {
-    return [
-      'system' => __('System'),
-      'brands' => __('Brands'),
-      'categories' => __('Categories'),
-      'collections' => __('Collections'),
-      'products' => __('Products'),
-      'customers' => __('Customers'),
-      'orders' => __('Orders'),
-      'discounts' => __('Discounts'),
-    ];
-  }
-}
+Permission::groups();
 ```
+
+This returns the eight built-in groups: `system`, `brands`, `categories`, `collections`, `products`, `customers`, `orders`, `discounts`.
 
 ## Components
 

--- a/v2/acl.mdx
+++ b/v2/acl.mdx
@@ -60,12 +60,12 @@ Permissions are associated with roles. Depending on the role that a member has, 
 
 All this management of roles and permissions is done using the [Laravel Permission](https://github.com/spatie/laravel-permission) package from [Spatie](https://spatie.be).
 
-At installation Laravel Shopper comes with 3 roles: **Administrator**, **Manager** and **User**, the user role cannot be modified from the administration interface
+At installation Shopper comes with 3 roles: **Administrator**, **Manager** and **User**, the user role cannot be modified from the administration interface
 because it is the role that will be assigned to any customer who will create his account on your shop.
 
 ## RBAC ACL
 
-RBAC (Role Based Access Control) or ACL (Access Control Layer) is an approach to restricting system access for users using roles system, Laravel Shopper allow to define
+RBAC (Role Based Access Control) or ACL (Access Control Layer) is an approach to restricting system access for users using roles system, Shopper allow to define
 the level of access for each user. With roles a user can access menus, pages. It is important to know that one Administrator can have multiple roles assigned.
 
 To view the roles and permissions management page, you must go to the **Settings > Staff & Permissions**
@@ -129,7 +129,7 @@ class Permission extends SpatiePermission
 
 ## Components
 
-During the installation of Laravel Shopper, no component files are published by default to ensure a streamlined and hassle-free setup.
+During the installation of Shopper, no component files are published by default to ensure a streamlined and hassle-free setup.
 However, if you need to customize or replace any components, you can easily publish them using the following Artisan command:
 
 ```bash

--- a/v2/addons.mdx
+++ b/v2/addons.mdx
@@ -1,0 +1,215 @@
+---
+title: Addons
+description: Extend the Shopper admin panel with self-contained addons, register routes, sidebar items, Livewire components, views, and settings without modifying core files.
+---
+
+Addons are the recommended way to package Shopper extensions. An addon is a self-contained unit that registers its routes, Livewire components, sidebar entries, views, and settings items through the `ShopperPanel` at boot time. When an addon is disabled, none of its assets are registered.
+
+## Creating an Addon
+
+An addon is a class that extends `Shopper\Addon\BaseAddon` and implements `Shopper\Contracts\ShopperAddon`. The contract requires four methods:
+
+| Method | Return | Description |
+|--------|--------|-------------|
+| `getId()` | `string` | Unique kebab-case identifier (`my-addon`) |
+| `getName()` | `string` | Display name; `BaseAddon` derives it from `getId()` automatically |
+| `register(ShopperPanel $panel)` | `void` | Called at registration time, bind routes, components, views, settings |
+| `boot(ShopperPanel $panel)` | `void` | Called after all addons are registered, use for cross-addon dependencies |
+| `isEnabled()` | `bool` | `BaseAddon` reads `config('shopper.addons.<id>')`, defaulting to `true` |
+
+A minimal addon looks like this:
+
+```php
+use Shopper\Addon\BaseAddon;
+use Shopper\ShopperPanel;
+
+final class AnalyticsAddon extends BaseAddon
+{
+    public function getId(): string
+    {
+        return 'analytics';
+    }
+
+    public function register(ShopperPanel $panel): void
+    {
+        $panel->addonRoutes(fn () => require __DIR__.'/../routes/analytics.php');
+
+        $panel->addonLivewireComponents([
+            'analytics-dashboard' => \App\Livewire\Analytics\Dashboard::class,
+            'analytics-report' => \App\Livewire\Analytics\Report::class,
+        ]);
+
+        $panel->addonViews('analytics', __DIR__.'/../resources/views');
+    }
+}
+```
+
+## Registering an Addon
+
+Register the addon in your application's service provider using the `Shopper` facade:
+
+```php
+use Shopper\Facades\Shopper;
+
+public function boot(): void
+{
+    Shopper::addon(new AnalyticsAddon);
+}
+```
+
+The `AddonManager` checks `isEnabled()` before registering. If the addon is disabled via config, `register()` is never called and nothing is loaded.
+
+## What an Addon Can Register
+
+### Routes
+
+```php
+$panel->addonRoutes(function () {
+    Route::middleware(['shopper'])->group(function () {
+        Route::get('/analytics', AnalyticsDashboard::class)->name('shopper.analytics.index');
+        Route::get('/analytics/{report}', AnalyticsReport::class)->name('shopper.analytics.report');
+    });
+});
+```
+
+### Livewire Components
+
+```php
+$panel->addonLivewireComponents([
+    'analytics-dashboard' => \App\Livewire\Analytics\Dashboard::class,
+]);
+```
+
+### Sidebar Navigation
+
+Pass a sidebar class that implements Shopper's sidebar extension interface:
+
+```php
+$panel->addonSidebar(\App\Sidebar\AnalyticsSidebar::class);
+```
+
+### Blade Views
+
+Register a view namespace so your Blade views are accessible as `analytics::dashboard`:
+
+```php
+$panel->addonViews('analytics', __DIR__.'/../resources/views');
+```
+
+### Settings Items
+
+Add entries to the Settings page. Each entry is a class-string mapped to a boolean controlling its visibility:
+
+```php
+$panel->addonSettingItems([
+    \App\Livewire\Settings\AnalyticsSettings::class => true,
+]);
+```
+
+### Permissions
+
+Declare additional permissions your addon introduces. They will be seeded alongside Shopper's built-in permissions:
+
+```php
+$panel->addonPermissions([
+    'browse_analytics',
+    'export_analytics',
+]);
+```
+
+### Styles and Scripts
+
+Inject additional CSS or JS assets into the admin panel's layout:
+
+```php
+$panel->addonStyles([asset('css/analytics.css')]);
+
+$panel->addonScripts([asset('js/analytics.js')]);
+```
+
+## Disabling an Addon
+
+Set the addon's ID to `false` in `config/shopper/addons.php`:
+
+```php
+return [
+    'analytics' => false,
+];
+```
+
+When set to `false`, `BaseAddon::isEnabled()` returns `false` and the addon's `register()` method is never called. Routes, components, sidebar entries, and assets are not loaded.
+
+## Checking if an Addon is Active
+
+```php
+use Shopper\Facades\Shopper;
+
+Shopper::hasAddon('analytics');
+
+$addon = Shopper::getAddon('analytics');
+$addon->getName();
+```
+
+## Full Example: A Loyalty Points Addon
+
+Here is a complete addon that adds a loyalty points feature to the Shopper admin:
+
+```php
+use Shopper\Addon\BaseAddon;
+use Shopper\ShopperPanel;
+
+final class LoyaltyAddon extends BaseAddon
+{
+    public function getId(): string
+    {
+        return 'loyalty';
+    }
+
+    public function register(ShopperPanel $panel): void
+    {
+        $panel->addonRoutes(function () {
+            Route::middleware(['shopper'])->prefix('loyalty')->name('shopper.loyalty.')->group(function () {
+                Route::get('/', \App\Livewire\Loyalty\Index::class)->name('index');
+                Route::get('/tiers', \App\Livewire\Loyalty\Tiers::class)->name('tiers');
+            });
+        });
+
+        $panel->addonLivewireComponents([
+            'loyalty-index' => \App\Livewire\Loyalty\Index::class,
+            'loyalty-tiers' => \App\Livewire\Loyalty\Tiers::class,
+            'loyalty-customer-points' => \App\Livewire\Loyalty\CustomerPoints::class,
+        ]);
+
+        $panel->addonViews('loyalty', __DIR__.'/../resources/views');
+
+        $panel->addonSidebar(\App\Sidebar\LoyaltySidebar::class);
+
+        $panel->addonPermissions([
+            'browse_loyalty',
+            'edit_loyalty',
+        ]);
+
+        $panel->addonSettingItems([
+            \App\Livewire\Settings\LoyaltySettings::class => true,
+        ]);
+    }
+
+    public function boot(ShopperPanel $panel): void
+    {
+        \Shopper\View\CustomerRenderHook::class;
+
+        $panel->renderHook(
+            \Shopper\View\CustomerRenderHook::SHOW_TABS_END,
+            fn (): string => '<livewire:loyalty-customer-points />',
+        );
+    }
+}
+```
+
+Register it once in your service provider:
+
+```php
+use Shopper\Facades\Shopper;
+
+Shopper::addon(new LoyaltyAddon);
+```

--- a/v2/cart.mdx
+++ b/v2/cart.mdx
@@ -1,0 +1,606 @@
+---
+title: Cart
+description: Manage shopping carts with pipeline-based calculation, discount validation, tax integration, and order conversion.
+---
+
+The `shopper/cart` package handles everything between "Add to cart" and "Place order". It manages cart lines, validates stock, applies discounts, calculates taxes, and converts completed carts into orders — all through a clean, testable API.
+
+Every monetary value is stored in **cents** as an unsigned integer. A product priced at $25.00 is stored as `2500`.
+
+## How It Works
+
+The cart system has five main pieces:
+
+1. **CartManager** handles cart operations: add, update, remove, apply coupons, calculate totals
+2. **CartSessionManager** persists the current cart in the session for storefront use
+3. **Pipeline system** calculates totals through a configurable chain of pipes (subtotals → discounts → taxes → total)
+4. **DiscountValidator** enforces coupon rules: eligibility, usage limits, zones, minimum amounts
+5. **CreateOrderFromCartAction** converts a cart into an order within a database transaction
+
+## Cart Manager
+
+The `CartManager` is the primary API for all cart operations. It is registered as a singleton and injected with the `CartPipelineRunner`.
+
+```php
+use Shopper\Cart\CartManager;
+
+$manager = resolve(CartManager::class);
+```
+
+### Adding Items
+
+Pass any model that implements `Priceable` — typically a `Product` or `ProductVariant`. The manager looks up the unit price from the purchasable's price list using the cart's currency.
+
+```php
+$line = $manager->add($cart, $product);
+
+$line = $manager->add($cart, $product, quantity: 3);
+
+$line = $manager->add($cart, $variant, metadata: [
+    'gift_wrap' => true,
+    'message' => 'Happy birthday!',
+]);
+```
+
+Adding the same purchasable twice increments the existing line's quantity instead of creating a duplicate.
+
+```php
+$manager->add($cart, $product, quantity: 2); // quantity: 2
+$manager->add($cart, $product, quantity: 3); // quantity: 5
+```
+
+### Stock Validation
+
+Every `add()` and `update()` call checks available stock. If the purchasable implements `Stockable` and `allow_backorder` is false, an `InsufficientStockException` is thrown when the requested quantity exceeds available inventory.
+
+```php
+use Shopper\Cart\Exceptions\InsufficientStockException;
+
+try {
+    $manager->add($cart, $product, quantity: 100);
+} catch (InsufficientStockException $e) {
+    $e->purchasable; // The product or variant
+    $e->available;   // Current stock level
+    $e->requested;   // Quantity that was requested
+}
+```
+
+Products with `allow_backorder` set to `true` bypass stock checks entirely.
+
+### Updating a Line
+
+```php
+$updated = $manager->update($cart, $lineId, [
+    'quantity' => 5,
+]);
+
+$updated = $manager->update($cart, $lineId, [
+    'metadata' => ['gift_wrap' => false],
+]);
+```
+
+### Removing Lines
+
+```php
+$manager->remove($cart, $lineId);
+
+$manager->clear($cart);
+```
+
+### Applying Coupons
+
+The `applyCoupon()` method validates that the discount code exists in the database before setting it on the cart. The actual discount calculation happens during the pipeline.
+
+```php
+use Shopper\Cart\Exceptions\InvalidDiscountException;
+
+try {
+    $manager->applyCoupon($cart, 'SUMMER20');
+} catch (InvalidDiscountException $e) {
+    // Discount code not found
+}
+
+$manager->removeCoupon($cart);
+```
+
+Removing a coupon also deletes all line adjustments that were created by the discount pipeline.
+
+### Adding Addresses
+
+```php
+use Shopper\Core\Enum\AddressType;
+
+$manager->addAddress($cart, AddressType::Shipping, [
+    'first_name' => 'John',
+    'last_name' => 'Doe',
+    'address_1' => '123 Main St',
+    'city' => 'New York',
+    'postal_code' => '10001',
+    'country_id' => $countryId,
+]);
+
+$manager->addAddress($cart, AddressType::Billing, $billingData);
+```
+
+If an address of the same type already exists, it is updated instead of duplicated.
+
+### Calculating Totals
+
+```php
+use Shopper\Cart\Pipelines\CartPipelineContext;
+
+$context = $manager->calculate($cart);
+
+$context->subtotal;      // Sum of line subtotals (before discounts/tax)
+$context->discountTotal; // Total discount amount
+$context->taxTotal;      // Total tax amount
+$context->total;         // Final total
+$context->taxInclusive;  // Whether tax is included in prices
+```
+
+### Completed Cart Guard
+
+All mutating operations (`add`, `update`, `remove`, `clear`, `applyCoupon`, `removeCoupon`) throw `CartCompletedException` if the cart has already been completed. This prevents modifications after an order has been placed.
+
+```php
+use Shopper\Cart\Exceptions\CartCompletedException;
+
+$cart->update(['completed_at' => now()]);
+
+$manager->add($cart, $product); // throws CartCompletedException
+```
+
+## Session Management
+
+The `CartSessionManager` handles cart persistence in the HTTP session. Use it in your storefront to retrieve or create the current customer's cart.
+
+### Using the Facade
+
+```php
+use Shopper\Cart\Facades\Cart;
+
+$cart = Cart::current();
+
+$cart = Cart::create();
+
+$cart = Cart::create(['channel_id' => $channelId, 'zone_id' => $zoneId]);
+
+Cart::use($existingCart);
+
+Cart::associate($user);
+
+Cart::forget();
+```
+
+### Behavior
+
+- `current()` returns `null` if no cart exists in the session and `auto_create` is `false`
+- `current()` returns `null` if the session cart has been completed (it won't return stale carts)
+- `create()` stores the new cart's ID in the session and sets the `currency_code` from `shopper_currency()`
+- `associate()` sets the `customer_id` on the current cart — call this after login
+- `forget()` removes the cart ID from the session without deleting the cart itself
+
+## Models
+
+### Cart
+
+```php
+Shopper\Cart\Models\Cart
+```
+
+| Column | Type | Nullable | Description |
+|--------|------|----------|-------------|
+| `id` | bigint | | Primary key |
+| `customer_id` | bigint | Yes | FK to `users` |
+| `channel_id` | bigint | Yes | FK to `shopper_channels` |
+| `zone_id` | bigint | Yes | FK to `shopper_zones` |
+| `currency_code` | string | | ISO currency code (e.g. `USD`) |
+| `coupon_code` | string | Yes | Applied discount code |
+| `completed_at` | timestamp | Yes | Set when cart is converted to order |
+| `metadata` | json | Yes | Custom data |
+| `created_at` | timestamp | | |
+| `updated_at` | timestamp | | |
+
+#### Relationships
+
+```php
+$cart->lines;            // HasMany<CartLine>
+$cart->addresses;        // HasMany<CartAddress>
+$cart->customer;         // BelongsTo<User>
+$cart->channel;          // BelongsTo<Channel>
+$cart->zone;             // BelongsTo<Zone>
+```
+
+#### Methods
+
+```php
+$cart->isCompleted();       // bool — checks if completed_at is set
+$cart->shippingAddress();   // ?CartAddress — address with type Shipping
+$cart->billingAddress();    // ?CartAddress — address with type Billing
+```
+
+### CartLine
+
+```php
+Shopper\Cart\Models\CartLine
+```
+
+| Column | Type | Nullable | Description |
+|--------|------|----------|-------------|
+| `id` | bigint | | Primary key |
+| `cart_id` | bigint | | FK to cart |
+| `purchasable_type` | string | | Morph type (`Product`, `ProductVariant`, etc.) |
+| `purchasable_id` | bigint | | Morph ID |
+| `quantity` | unsigned int | | Item quantity |
+| `unit_price_amount` | unsigned int | | Price per unit in cents |
+| `metadata` | json | Yes | Custom data |
+
+#### Relationships
+
+```php
+$line->cart;           // BelongsTo<Cart>
+$line->purchasable;    // MorphTo — Product, ProductVariant, etc.
+$line->adjustments;    // HasMany<CartLineAdjustment>
+$line->taxLines;       // HasMany<CartLineTaxLine>
+```
+
+### CartAddress
+
+```php
+Shopper\Cart\Models\CartAddress
+```
+
+| Column | Type | Nullable | Description |
+|--------|------|----------|-------------|
+| `id` | bigint | | Primary key |
+| `cart_id` | bigint | | FK to cart |
+| `type` | string | | `shipping` or `billing` (AddressType enum) |
+| `country_id` | bigint | Yes | FK to `shopper_countries` |
+| `first_name` | string | Yes | |
+| `last_name` | string | | |
+| `company` | string | Yes | |
+| `address_1` | string | | Street address |
+| `address_2` | string | Yes | Apartment, suite, etc. |
+| `city` | string | | |
+| `state` | string | Yes | |
+| `postal_code` | string | | |
+| `phone` | string | Yes | |
+
+The `full_name` accessor combines `first_name` and `last_name`.
+
+### CartLineAdjustment
+
+```php
+Shopper\Cart\Models\CartLineAdjustment
+```
+
+| Column | Type | Nullable | Description |
+|--------|------|----------|-------------|
+| `id` | bigint | | Primary key |
+| `cart_line_id` | bigint | | FK to cart line |
+| `discount_id` | bigint | Yes | FK to discount |
+| `amount` | unsigned int | | Discount amount in cents |
+| `code` | string | Yes | Coupon code |
+
+### CartLineTaxLine
+
+```php
+Shopper\Cart\Models\CartLineTaxLine
+```
+
+| Column | Type | Nullable | Description |
+|--------|------|----------|-------------|
+| `id` | bigint | | Primary key |
+| `cart_line_id` | bigint | | FK to cart line |
+| `tax_rate_id` | bigint | Yes | FK to tax rate |
+| `code` | string | | Tax code |
+| `name` | string | | Tax name (e.g. "VAT") |
+| `rate` | decimal(8,4) | | Tax rate (e.g. `20.0000` for 20%) |
+| `amount` | unsigned int | | Tax amount in cents |
+
+## Calculation Pipeline
+
+Cart totals are calculated through a pipeline of configurable steps. Each pipe receives a `CartPipelineContext`, performs its calculation, and passes it to the next pipe.
+
+### Default Pipeline
+
+```php
+use Shopper\Cart\Pipelines\CalculateLines;
+use Shopper\Cart\Pipelines\ApplyDiscounts;
+use Shopper\Cart\Pipelines\CalculateTax;
+use Shopper\Cart\Pipelines\Calculate;
+
+// config/shopper/cart.php
+'pipelines' => [
+    'cart' => [
+        CalculateLines::class,
+        ApplyDiscounts::class,
+        CalculateTax::class,
+        Calculate::class,
+    ],
+],
+```
+
+### Pipeline Steps
+
+**1. CalculateLines** — Computes the subtotal for each line (`unit_price_amount × quantity`) and sums them into `$context->subtotal`.
+
+**2. ApplyDiscounts** — If the cart has a `coupon_code`, validates the discount through `DiscountValidator` and calculates the discount amount. For percentage discounts, each line gets `(lineSubtotal × rate / 100)`. For fixed amount discounts, the amount is distributed proportionally across lines. Creates `CartLineAdjustment` records.
+
+**3. CalculateTax** — Resolves the shipping address country and calculates tax for each line using the core `TaxCalculator`. The taxable amount per line is `(lineSubtotal - discountAmount)`. Creates `CartLineTaxLine` records.
+
+**4. Calculate** — Computes the final total. If tax is inclusive: `total = subtotal - discountTotal`. If tax is exclusive: `total = subtotal - discountTotal + taxTotal`. The minimum total is always `0`.
+
+### Custom Pipeline
+
+You can replace or extend the pipeline in `config/shopper/cart.php`. Add a custom pipe to handle shipping costs, loyalty points, or any other calculation:
+
+```php
+'pipelines' => [
+    'cart' => [
+        CalculateLines::class,
+        ApplyDiscounts::class,
+        App\Cart\Pipes\ApplyShippingCost::class,
+        CalculateTax::class,
+        Calculate::class,
+    ],
+],
+```
+
+Your custom pipe must implement `__invoke(CartPipelineContext $context, Closure $next)`:
+
+```php
+namespace App\Cart\Pipes;
+
+use Closure;
+use Shopper\Cart\Pipelines\CartPipelineContext;
+
+final class ApplyShippingCost
+{
+    public function __invoke(CartPipelineContext $context, Closure $next): mixed
+    {
+        // Your calculation logic here
+
+        return $next($context);
+    }
+}
+```
+
+## Discount Validation
+
+When a coupon is applied during the pipeline, the `DiscountValidator` runs a series of checks before the discount is calculated. Each check produces a clear, translatable error message.
+
+### Validation Rules
+
+| Rule | Condition | Error Key |
+|------|-----------|-----------|
+| Active | `discount->is_active` must be true | `discount.not_active` |
+| Started | `discount->start_at` must be in the past | `discount.not_started` |
+| Not expired | `discount->end_at` must be null or in the future | `discount.expired` |
+| Usage limit | Total uses must be under the global limit | `discount.usage_limit_reached` |
+| Per-user limit | Customer must not have exceeded their per-user limit | `discount.already_used` |
+| Eligibility | If restricted to specific customers, the cart customer must be in the list | `discount.customer_not_eligible` |
+| Requires login | If eligibility is set, the cart must have a `customer_id` | `discount.requires_login` |
+| Zone | If the discount has a `zone_id`, it must match `cart->zone_id` | `discount.not_available_in_zone` |
+| Minimum amount | Cart subtotal must meet the minimum purchase requirement | `discount.min_amount_not_reached` |
+| Minimum quantity | Total line quantity must meet the minimum quantity requirement | `discount.min_quantity_not_reached` |
+
+### Discount Application Modes
+
+Discounts support two application scopes via `discount->apply_to`:
+
+- **Order** (`DiscountApplyTo::Order`) — applies to all cart lines
+- **Specific products** — applies only to lines matching the products/variants configured on the discount
+
+And two discount types:
+
+- **Percentage** — each applicable line gets `(lineSubtotal × value / 100)`
+- **Fixed amount** — the fixed amount is distributed proportionally across applicable lines based on their share of the total subtotal
+
+## Order Conversion
+
+The `CreateOrderFromCartAction` converts a completed cart into an order. This is the bridge between the storefront cart and the order management system.
+
+```php
+use Shopper\Cart\Actions\CreateOrderFromCartAction;
+
+$action = resolve(CreateOrderFromCartAction::class);
+$order = $action->execute($cart);
+```
+
+### What Happens
+
+The entire operation runs inside a database transaction with a `FOR UPDATE` lock on the cart:
+
+1. **Calculates totals** — runs the full pipeline to get final amounts
+2. **Creates order addresses** — copies cart shipping/billing addresses to `OrderAddress` records
+3. **Creates the order** — with `price_amount`, `tax_amount`, `currency_code`, and all foreign keys
+4. **Creates order items** — one per cart line, including the discount amount from adjustments
+5. **Creates order tax lines** — via `CreateOrderTaxLinesAction`
+6. **Increments discount usage** — if a coupon was applied, increments `total_use` on the discount
+7. **Marks cart as completed** — sets `completed_at` to prevent further modifications
+8. **Dispatches `CartCompleted` event** — with the cart and the created order
+
+<Note>
+If the cart has already been completed, `CartCompletedException` is thrown before any work begins. The `FOR UPDATE` lock prevents race conditions from concurrent checkout attempts.
+</Note>
+
+## Events
+
+| Event | Dispatched When | Properties |
+|-------|-----------------|------------|
+| `CartCompleted` | Cart is converted to an order | `Cart $cart`, `Order $order` |
+| `CouponApplied` | Coupon code is set on a cart | `Cart $cart`, `string $code` |
+| `CouponRemoved` | Coupon code is cleared from a cart | `Cart $cart` |
+
+```php
+use Shopper\Cart\Events\CartCompleted;
+use Shopper\Cart\Events\CouponApplied;
+use Shopper\Cart\Events\CouponRemoved;
+```
+
+## Configuration
+
+Publish the configuration file:
+
+```bash
+php artisan vendor:publish --tag=shopper-cart-config
+```
+
+```php
+// config/shopper/cart.php
+
+return [
+    'pipelines' => [
+        'cart' => [
+            CalculateLines::class,
+            ApplyDiscounts::class,
+            CalculateTax::class,
+            Calculate::class,
+        ],
+    ],
+
+    'session' => [
+        'key' => 'shopper_cart',     // Session key for storing cart ID
+        'auto_create' => false,      // Auto-create cart when current() is called
+    ],
+
+    'prune_after_days' => 30,        // Days before abandoned carts are pruned
+
+    'models' => [
+        'cart' => Cart::class,       // Swappable via model contracts
+        'cart_line' => CartLine::class,
+    ],
+];
+```
+
+### Model Swapping
+
+The `Cart` and `CartLine` models implement core contracts (`CartContract`, `CartLineContract`) and use the `HasModelContract` trait. You can replace them with your own models:
+
+```php
+// config/shopper/cart.php
+'models' => [
+    'cart' => App\Models\Cart::class,
+    'cart_line' => App\Models\CartLine::class,
+],
+```
+
+Your custom models must implement the corresponding contracts from `Shopper\Core\Models\Contracts`.
+
+## Pruning Abandoned Carts
+
+Abandoned carts (never completed) are cleaned up with a scheduled command:
+
+```bash
+php artisan shopper:prune-carts
+php artisan shopper:prune-carts --days=7
+```
+
+By default, carts that haven't been updated in the last 30 days (configurable via `prune_after_days`) are deleted. Only carts where `completed_at` is `null` are pruned — completed carts are kept as historical records.
+
+Schedule the command in your `routes/console.php`:
+
+```php
+use Illuminate\Support\Facades\Schedule;
+
+Schedule::command('shopper:prune-carts')->daily();
+```
+
+## Storefront Example
+
+Here is a complete cart-to-checkout flow for a storefront application.
+
+### Initializing the Cart
+
+```php
+use Shopper\Cart\Facades\Cart;
+
+// In middleware or controller — get or create the cart
+$cart = Cart::current() ?? Cart::create([
+    'channel_id' => $channel->id,
+    'zone_id' => $zone->id,
+]);
+
+// After login — associate the customer
+Cart::associate(auth()->user());
+```
+
+### Adding Products
+
+```php
+use Shopper\Cart\CartManager;
+use Shopper\Cart\Exceptions\InsufficientStockException;
+use Shopper\Cart\Facades\Cart;
+
+$cart = Cart::current();
+$manager = resolve(CartManager::class);
+
+try {
+    $manager->add($cart, $product, quantity: 2);
+} catch (InsufficientStockException $e) {
+    return back()->with('error', "Only {$e->available} items available.");
+}
+```
+
+### Displaying Cart Totals
+
+```php
+$context = $manager->calculate($cart);
+
+// In your Blade template
+Subtotal: {{ format_money($context->subtotal, $cart->currency_code) }}
+Discount: -{{ format_money($context->discountTotal, $cart->currency_code) }}
+Tax: {{ format_money($context->taxTotal, $cart->currency_code) }}
+Total: {{ format_money($context->total, $cart->currency_code) }}
+```
+
+### Applying a Coupon
+
+```php
+use Shopper\Cart\Exceptions\InvalidDiscountException;
+
+try {
+    $manager->applyCoupon($cart, $couponCode);
+} catch (InvalidDiscountException $e) {
+    return back()->with('error', $e->getMessage());
+}
+
+// Recalculate to see the discount
+$context = $manager->calculate($cart);
+```
+
+### Setting Addresses
+
+```php
+use Shopper\Core\Enum\AddressType;
+
+$manager->addAddress($cart, AddressType::Shipping, [
+    'first_name' => $request->first_name,
+    'last_name' => $request->last_name,
+    'address_1' => $request->address,
+    'city' => $request->city,
+    'postal_code' => $request->postal_code,
+    'country_id' => $request->country_id,
+]);
+```
+
+### Converting to Order
+
+```php
+use Shopper\Cart\Actions\CreateOrderFromCartAction;
+use Shopper\Cart\Facades\Cart;
+
+$action = resolve(CreateOrderFromCartAction::class);
+$order = $action->execute(Cart::current());
+
+Cart::forget();
+
+// Continue to payment processing
+$service = resolve(PaymentProcessingService::class);
+$result = $service->initiate($order);
+```
+
+<Note>
+After converting the cart to an order, call `Cart::forget()` to clear the session. The cart is marked as completed and cannot be modified, but the session should be cleaned up so `Cart::current()` returns `null`. See the [Payments](/v2/payments) page for processing the order payment.
+</Note>

--- a/v2/configuration.mdx
+++ b/v2/configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Configuration"
-description: "Configuration options for Laravel Shopper"
+description: "Configuration options for Shopper"
 ---
 
 Shopper uses standard Laravel config files and environment variables for application-level settings.
@@ -114,7 +114,7 @@ Routes added in the sidebar have the middleware applied to the dashboard, you mu
 
 The main features of Shopper is to handle Livewire components to add new functionalities to your admin panel.
 
-For this purpose you have components files that lists each Livewire components used within Laravel Shopper.
+For this purpose you have components files that lists each Livewire components used within Shopper.
 You can extend component to add functionality and even change the view to fit your own logic.
 
 Here is a list of components files available. All these files can be published with `php artisan shopper:component:publish`

--- a/v2/contributing.mdx
+++ b/v2/contributing.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Contribution Guide"
-description: "Guidelines for contributing to Laravel Shopper"
+description: "Guidelines for contributing to Shopper"
 ---
 
 Contributions are accepted via Pull Requests on [Github](https://github.com/shopperlabs/shopper).

--- a/v2/currencies.mdx
+++ b/v2/currencies.mdx
@@ -6,12 +6,12 @@ description: Configure and manage multiple currencies for your global store
 Currencies play a crucial role in defining the prices of products, services, and other monetary details within your e-commerce system.
 Whether you're running a local store or a global marketplace.
 
-Laravel Shopper is designed to support **multi-currency functionality**, allowing you to define prices in different currencies and tailor them to
+Shopper is designed to support **multi-currency functionality**, allowing you to define prices in different currencies and tailor them to
 specific [zones](/v2/zones). This flexibility ensures that you can cater to a global audience without any limitations related to pricing.
 With Shopper, you can effortlessly set up and manage multiple currencies, ensuring that your customers see prices in their preferred currency,
 no matter where they are located.
 
-In this documentation, you'll learn how to configure and utilize currencies within your Laravel Shopper project. Whether you're setting up
+In this documentation, you'll learn how to configure and utilize currencies within your Shopper project. Whether you're setting up
 your first currency or managing a complex multi-currency setup, this guide will provide you with the tools and knowledge you need to make the most
 of Shopper's currency features.
 

--- a/v2/dashboard.mdx
+++ b/v2/dashboard.mdx
@@ -1,43 +1,125 @@
 ---
 title: Dashboard
-description: Learn how to manage Dashboard in your Shopper administration.
+description: Overview of the admin dashboard, analytics components, the setup guide, and how to customize or replace the dashboard page.
 ---
 
-The dashboard is a user-customizable screen. One of Shopper's main goals is to enable stores to easily customize the modules.
-
-## Overview
-
-When you log into the control panel, you will be taken to the dashboard — a customizable screen dispatch with a Livewire component!
-
-Shopper is a free open-source e-commerce application based on the [TALL Stack](https://tallstack.dev) and aims to build an e-commerce administration using only [Livewire](https://laravel.livewire.com) components.
-
-The navigation at the left contains the available panels for everyday use:
-
-<Frame caption="The dashboard and the Getting Started panel">
-  <img src="/images/v2/dashboard.png" alt="Shopper Global Set Example" />
-</Frame>
-
-Clicking on each icon will open the panel or shows a list of available panels.
+The dashboard is the first screen after login. It shows store health at a glance: revenue trends, key metrics, recent orders, top products, and an onboarding guide that auto-dismisses once the store is configured.
 
 ## Components
 
-The component that displays the dashboard is quite simple, so you can easily replace it to put your own.
+The dashboard is composed of five Livewire components, each with independent caching and a focused responsibility.
 
-The component used is `Shopper\Livewire\Pages\Dashboard` and can also be found in the components file `config/shopper/components/dashboard.php`.
+### RevenueChart
+
+Displays monthly revenue as a bar chart for the last 12 months. Data is grouped by month in a single aggregated query and cached with stale-while-revalidate semantics (fresh for 5 minutes, stale up to 30 minutes).
+
+The chart supports a currency filter — when you have multiple active currencies, a dropdown lets you switch between them. The Y-axis and tooltip are formatted using `Intl.NumberFormat` with the store's locale and currency symbol.
+
+### StatCards
+
+Shows four summary cards comparing the current month to the previous month:
+
+| Card | Metric | Scope |
+|------|--------|-------|
+| Revenue | Sum of `price_amount` on paid orders | Current currency |
+| Products | Total product count, monthly new products for trend | All types |
+| Orders | Count of paid orders, monthly count for trend | All currencies |
+| Customers | Count of users with the `customer` scope, monthly new customers for trend | — |
+
+Each card shows the percentage change versus the previous month, with a green/red trend indicator.
+
+### RecentOrders
+
+A table of the 10 most recent orders. Each row shows the order number, customer name, total amount, payment status, and a link to the order detail page.
+
+### TopSellingProducts
+
+Ranks the top 5 products by total quantity sold. Variant sales are aggregated back to the parent product. Each row shows the product thumbnail, name, total units sold, and average review score.
+
+### SetupGuide
+
+An interactive checklist that guides new stores through the essential configuration steps. It auto-detects completion by querying the database:
+
+| Step | Completed when |
+|------|---------------|
+| Add a product | At least one product exists |
+| Create a collection | At least one collection exists |
+| Set up shipping zones | At least one enabled shipping zone exists |
+| Set up payment methods | At least one enabled payment method exists |
+| Configure taxes | At least one tax zone exists |
+
+When all steps are marked complete, the guide saves a `setup_guide_done` setting and dispatches a `setup-guide-completed` event to hide itself. It does not reappear on subsequent visits.
+
+## Customizing the Dashboard
+
+The dashboard page component is registered in the components configuration file. You can replace it with your own implementation.
+
+Publish the configuration:
+
+```bash
+php artisan vendor:publish --tag=shopper-config
+```
+
+Then open `config/shopper/components/dashboard.php` and replace the page class:
 
 ```php
-namespace Shopper\Livewire\Pages;
+use Shopper\Livewire\Pages;
+
+return [
+    'pages' => [
+        'dashboard' => Pages\Dashboard::class,
+    ],
+    'components' => [
+        'side-panel' => Components\SlideOverPanel::class,
+    ],
+];
+```
+
+Point it to your own component:
+
+```php
+'pages' => [
+    'dashboard' => App\Livewire\Pages\Dashboard::class,
+],
+```
+
+Your component only needs to render the correct view with the app layout. The simplest override:
+
+```php
+namespace App\Livewire\Pages;
 
 use Illuminate\Contracts\View\View;
+use Livewire\Component;
 
-class Dashboard extends AbstractPageComponent
+final class Dashboard extends Component
 {
     public function render(): View
     {
-        return view('shopper::livewire.pages.dashboard')
+        return view('dashboard.index')
             ->layout('shopper::components.layouts.app', [
-                'title' => __('shopper::layout.sidebar.dashboard'),
+                'title' => 'Dashboard',
             ]);
     }
 }
 ```
+
+## Adding Content via Render Hooks
+
+If you only want to inject content above or below the dashboard without replacing the entire page, use the layout render hooks:
+
+```php
+use Shopper\Facades\Shopper;
+use Shopper\View\LayoutRenderHook;
+
+Shopper::renderHook(
+    LayoutRenderHook::DASHBOARD_START,
+    fn (): string => view('dashboard.store-alert-banner')->render(),
+);
+
+Shopper::renderHook(
+    LayoutRenderHook::DASHBOARD_END,
+    fn (): string => view('dashboard.custom-reports')->render(),
+);
+```
+
+See the [Render Hooks](/v2/render-hooks) documentation for the full list of available injection points.

--- a/v2/dashboard.mdx
+++ b/v2/dashboard.mdx
@@ -9,7 +9,7 @@ The dashboard is a user-customizable screen. One of Shopper's main goals is to e
 
 When you log into the control panel, you will be taken to the dashboard — a customizable screen dispatch with a Livewire component!
 
-Laravel Shopper is a free open-source e-commerce application based on the [TALL Stack](https://tallstack.dev) and aims to build an e-commerce administration using only [Livewire](https://laravel.livewire.com) components.
+Shopper is a free open-source e-commerce application based on the [TALL Stack](https://tallstack.dev) and aims to build an e-commerce administration using only [Livewire](https://laravel.livewire.com) components.
 
 The navigation at the left contains the available panels for everyday use:
 

--- a/v2/demo-store.mdx
+++ b/v2/demo-store.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Demo Store"
-description: "A fully functional e-commerce demo built with Laravel Shopper to showcase real-world usage."
+description: "A fully functional e-commerce demo built with Shopper to showcase real-world usage."
 ---
 
 We've built a complete demo store to showcase what's possible with Shopper. It's a fully functional e-commerce application

--- a/v2/events.mdx
+++ b/v2/events.mdx
@@ -1,11 +1,14 @@
 ---
 title: Events
-description: Reference for all events dispatched by Shopper during order and product lifecycle operations.
+description: Reference for all events dispatched by Shopper during order, product, and cart lifecycle operations.
 ---
 
-Shopper dispatches events at key moments in the order and product lifecycle. These events allow you to hook into the system and add custom behavior — sending notifications, syncing with external services, updating analytics, or triggering workflows — without modifying any Shopper code.
+Shopper dispatches events at key moments in the order, product, and cart lifecycle. These events allow you to hook into the system and add custom behavior — sending notifications, syncing with external services, updating analytics, or triggering workflows — without modifying any Shopper code.
 
-All events are located in the `Shopper\Core\Events` namespace and are organized by domain.
+Events are organized by domain across two namespaces:
+
+- `Shopper\Core\Events` — order and product events
+- `Shopper\Cart\Events` — cart events
 
 ```php
 use Shopper\Core\Events\Orders\OrderCompleted;
@@ -236,6 +239,47 @@ class SendShippingConfirmation implements ShouldQueue
 }
 ```
 
+## Cart Events
+
+Cart events are dispatched when a cart reaches a key state during the checkout process.
+
+### Available Events
+
+| Event | Payload | Trigger |
+|-------|---------|---------|
+| `CartCompleted` | `Cart $cart` | Cart is converted to an order |
+| `CouponApplied` | `Cart $cart`, `string $code` | A coupon code is successfully applied to the cart |
+| `CouponRemoved` | `Cart $cart`, `string $code` | A coupon code is removed from the cart |
+
+Cart events are in the `Shopper\Cart\Events` namespace:
+
+```php
+use Shopper\Cart\Events\CartCompleted;
+use Shopper\Cart\Events\CouponApplied;
+use Shopper\Cart\Events\CouponRemoved;
+```
+
+### Example: Sending a Cart Recovery Email on Coupon Removal
+
+```php
+use Shopper\Cart\Events\CouponRemoved;
+
+class OfferAlternativeCoupon
+{
+    public function handle(CouponRemoved $event): void
+    {
+        $cart = $event->cart;
+        $removedCode = $event->code;
+
+        $customer = $cart->customer;
+
+        if ($customer) {
+            Mail::to($customer->email)->send(new AlternativeDiscountMail($cart));
+        }
+    }
+}
+```
+
 ## All Events Reference
 
 | Namespace | Event | Payload | Queued |
@@ -253,3 +297,6 @@ class SendShippingConfirmation implements ShouldQueue
 | `Events\Products` | `ProductCreated` | `Product $product` | Yes |
 | `Events\Products` | `ProductUpdated` | `Product $product` | Yes |
 | `Events\Products` | `ProductDeleted` | `Product $product` | Yes |
+| `Cart\Events` | `CartCompleted` | `Cart $cart` | No |
+| `Cart\Events` | `CouponApplied` | `Cart $cart`, `string $code` | No |
+| `Cart\Events` | `CouponRemoved` | `Cart $cart`, `string $code` | No |

--- a/v2/events.mdx
+++ b/v2/events.mdx
@@ -62,10 +62,10 @@ Order events cover the full lifecycle of a purchase — from creation to complet
 | `OrderPaid` | `Order $order` | Admin marks order as paid |
 | `OrderCompleted` | `Order $order` | Admin marks order as completed |
 | `OrderShipped` | `Order $order` | All items reach shipped status |
-| `OrderCancel` | `Order $order` | Admin cancels the order |
+| `OrderCancelled` | `Order $order` | Admin cancels the order |
 | `OrderArchived` | `Order $order` | Admin archives the order |
 | `OrderDeleted` | `Order $order` | Order is soft-deleted |
-| `AddNoteToOrder` | `Order $order` | Admin adds a note to the order |
+| `OrderNoteAdded` | `Order $order` | Admin adds a note to the order |
 
 All order events carry a single `public Order $order` property.
 
@@ -78,9 +78,9 @@ OrderCreated
     │       │
     │       ├── OrderShipped ──→ OrderCompleted
     │       │
-    │       └── OrderCancel
+    │       └── OrderCancelled
     │
-    ├── OrderCancel
+    ├── OrderCancelled
     │
     ├── OrderArchived
     │
@@ -97,13 +97,13 @@ use Shopper\Core\Models\Order;
 $order = Order::query()->create([...]);
 ```
 
-Status-related events (`OrderPaid`, `OrderCompleted`, `OrderCancel`, `OrderArchived`) are dispatched from the admin panel when an administrator changes the order status.
+Status-related events (`OrderPaid`, `OrderCompleted`, `OrderCancelled`, `OrderArchived`) are dispatched from the admin panel when an administrator changes the order status.
 
 `OrderShipped` is dispatched by `SyncOrderShippingStatusAction` when the aggregated shipping status of all items transitions to `Shipped`. This happens automatically after shipment events are recorded — you don't dispatch it manually.
 
 ### Queueing
 
-Most order events implement `ShouldQueueAfterCommit`, meaning listeners run on the queue after the database transaction commits. `AddNoteToOrder` is synchronous.
+All order events implement `ShouldDispatchAfterCommit`, meaning listeners run on the queue after the database transaction commits.
 
 | Event | Queued |
 |-------|--------|
@@ -111,10 +111,10 @@ Most order events implement `ShouldQueueAfterCommit`, meaning listeners run on t
 | `OrderPaid` | Yes |
 | `OrderCompleted` | Yes |
 | `OrderShipped` | Yes |
-| `OrderCancel` | Yes |
+| `OrderCancelled` | Yes |
 | `OrderArchived` | Yes |
 | `OrderDeleted` | Yes |
-| `AddNoteToOrder` | No |
+| `OrderNoteAdded` | Yes |
 
 ## Shipment Events
 
@@ -124,10 +124,10 @@ Shipment events track the creation and delivery of individual packages within an
 
 | Event | Payload | Trigger |
 |-------|---------|---------|
-| `OrderShipmentCreated` | `Order $order` | A new shipment is created with a shipping label |
+| `OrderShipmentCreated` | `Order $order`, `OrderShipping $shipment` | A new shipment is created with a shipping label |
 | `OrderShipmentDelivered` | `Order $order`, `OrderShipping $shipment` | A shipment is marked as delivered |
 
-`OrderShipmentDelivered` is the only event that carries two properties — the order and the specific shipment that was delivered. This is useful when an order has multiple packages and you need to know which one arrived.
+Both shipment events carry two properties — the order and the specific shipment. This is useful when an order has multiple packages and you need to know which one was created or delivered.
 
 ```php
 use Shopper\Core\Events\Orders\OrderShipmentDelivered;
@@ -183,7 +183,7 @@ class SyncProductToCatalog
 ```
 
 <Note>
-Product events are synchronous (`ProductCreated`, `ProductUpdated`) except for `ProductDeleted` which implements `ShouldQueueAfterCommit`.
+All product events implement `ShouldDispatchAfterCommit` — listeners run on the queue after the database transaction commits.
 </Note>
 
 ## Example: Order Notification System
@@ -244,12 +244,12 @@ class SendShippingConfirmation implements ShouldQueue
 | `Events\Orders` | `OrderPaid` | `Order $order` | Yes |
 | `Events\Orders` | `OrderCompleted` | `Order $order` | Yes |
 | `Events\Orders` | `OrderShipped` | `Order $order` | Yes |
-| `Events\Orders` | `OrderCancel` | `Order $order` | Yes |
+| `Events\Orders` | `OrderCancelled` | `Order $order` | Yes |
 | `Events\Orders` | `OrderArchived` | `Order $order` | Yes |
 | `Events\Orders` | `OrderDeleted` | `Order $order` | Yes |
-| `Events\Orders` | `AddNoteToOrder` | `Order $order` | No |
-| `Events\Orders` | `OrderShipmentCreated` | `Order $order` | Yes |
+| `Events\Orders` | `OrderNoteAdded` | `Order $order` | Yes |
+| `Events\Orders` | `OrderShipmentCreated` | `Order $order`, `OrderShipping $shipment` | Yes |
 | `Events\Orders` | `OrderShipmentDelivered` | `Order $order`, `OrderShipping $shipment` | Yes |
-| `Events\Products` | `ProductCreated` | `Product $product` | No |
-| `Events\Products` | `ProductUpdated` | `Product $product` | No |
+| `Events\Products` | `ProductCreated` | `Product $product` | Yes |
+| `Events\Products` | `ProductUpdated` | `Product $product` | Yes |
 | `Events\Products` | `ProductDeleted` | `Product $product` | Yes |

--- a/v2/extending/control-panel.mdx
+++ b/v2/extending/control-panel.mdx
@@ -175,25 +175,37 @@ The priority order is: `Shopper::brandLogo()` > `config('shopper.admin.brand')` 
 
 ## Render hooks
 
-Shopper allows you to render Blade content at specific points in the admin panel layout. This is useful for integrating third-party packages that require Blade components in the layout, such as [Flux UI](https://fluxui.dev), [Wire Elements Modal](https://github.com/wire-elements/modal), or [Laravel Notify](https://github.com/mckenziearts/laravel-notify).
+Shopper allows you to render Blade content at specific points in the admin panel. This is useful for integrating third-party packages that require Blade components in the layout, such as [Flux UI](https://fluxui.dev), [Wire Elements Modal](https://github.com/wire-elements/modal), or [Laravel Notify](https://github.com/mckenziearts/laravel-notify), and for addons that need to inject content into specific pages.
 
 <Info>
-If you are familiar with [Filament's render hooks](https://filamentphp.com/docs/3.x/support/render-hooks), you already know how this works. Shopper's render hooks follow the same concept.
+If you are familiar with [Filament's render hooks](https://filamentphp.com/docs/5.x/support/render-hooks), you already know how this works. Shopper's render hooks follow the same concept.
 </Info>
+
+Render hooks are organized into scoped classes by business domain under the `Shopper\View` namespace:
+
+| Class | Scope |
+|-------|-------|
+| `LayoutRenderHook` | Head, body, header, content, dashboard, account, settings |
+| `ProductRenderHook` | Product index, edit, variant |
+| `OrderRenderHook` | Order index, detail, shipments, abandoned carts |
+| `CustomerRenderHook` | Customer index, create, show |
+| `CollectionRenderHook` | Collection index, edit |
+| `CatalogRenderHook` | Categories, brands, tags, attributes, reviews |
+| `SalesRenderHook` | Discounts, suppliers |
 
 ### Registering a render hook
 
-To register a render hook, call the `Shopper::renderHook()` method from a service provider's `boot` method. The first argument is the hook position (using the `RenderHook` enum), and the second is a closure that returns HTML:
+To register a render hook, call the `Shopper::renderHook()` method from a service provider's `boot` method. The first argument is the hook constant, and the second is a closure that returns HTML:
 
 ```php
 use Illuminate\Support\Facades\Blade;
-use Shopper\Enum\RenderHook;
 use Shopper\Facades\Shopper;
+use Shopper\View\LayoutRenderHook;
 
 public function boot(): void
 {
     Shopper::renderHook(
-        RenderHook::BodyEnd,
+        LayoutRenderHook::BODY_END,
         fn (): string => Blade::render('@livewire("wire-elements-modal")'),
     );
 }
@@ -203,40 +215,141 @@ Since all methods return the `ShopperPanel` instance, you can chain multiple cal
 
 ```php
 use Illuminate\Support\Facades\Blade;
-use Shopper\Enum\RenderHook;
 use Shopper\Facades\Shopper;
+use Shopper\View\LayoutRenderHook;
 
 public function boot(): void
 {
-    Shopper::renderHook(RenderHook::HeadEnd, fn (): string => Blade::render('@fluxStyles'))
-        ->renderHook(RenderHook::BodyEnd, fn (): string => Blade::render('<flux:modal />'))
-        ->renderHook(RenderHook::BodyEnd, fn (): string => Blade::render('<x-notify::notify />'))
+    Shopper::renderHook(LayoutRenderHook::HEAD_END, fn (): string => Blade::render('@fluxStyles'))
+        ->renderHook(LayoutRenderHook::BODY_END, fn (): string => Blade::render('<flux:modal />'))
+        ->renderHook(LayoutRenderHook::BODY_END, fn (): string => Blade::render('<x-notify::notify />'))
         ->registerViteTheme('resources/css/shopper.css')
         ->styles(['vendor/custom/lib.css'])
         ->scripts(['vendor/custom/lib.js']);
 }
 ```
 
+You can also use hooks from different scoped classes to inject content into specific pages:
+
+```php
+use Illuminate\Support\Facades\Blade;
+use Shopper\Facades\Shopper;
+use Shopper\View\ProductRenderHook;
+
+Shopper::renderHook(
+    ProductRenderHook::EDIT_HEADER_AFTER,
+    fn (): string => Blade::render('<livewire:my-addon.product-banner />'),
+);
+```
+
 ### Available render hooks
 
-| Hook | Enum | Description |
-|------|------|-------------|
-| Head Start | `RenderHook::HeadStart` | After the meta tags, before Filament styles and Shopper theme |
-| Head End | `RenderHook::HeadEnd` | End of `<head>`, after all styles and scripts |
-| Body Start | `RenderHook::BodyStart` | Start of `<body>`, before any content |
-| Body End | `RenderHook::BodyEnd` | End of `<body>`, after Filament scripts |
-| Content Start | `RenderHook::ContentStart` | Start of the main content area (inside the layout, after the sidebar) |
-| Content End | `RenderHook::ContentEnd` | End of the main content area |
+#### Layout
+
+| Constant | Class | Description |
+|----------|-------|-------------|
+| `HEAD_START` | `LayoutRenderHook` | After the meta tags, before Filament styles and Shopper theme |
+| `HEAD_END` | `LayoutRenderHook` | End of `<head>`, after all styles and scripts |
+| `BODY_START` | `LayoutRenderHook` | Start of `<body>`, before any content |
+| `BODY_END` | `LayoutRenderHook` | End of `<body>`, after Filament scripts |
+| `HEADER_START` | `LayoutRenderHook` | Start of the header bar content area |
+| `HEADER_END` | `LayoutRenderHook` | End of the header bar, before the site link and account dropdown |
+| `CONTENT_START` | `LayoutRenderHook` | Start of the main content area, after the sidebar |
+| `CONTENT_END` | `LayoutRenderHook` | End of the main content area |
+| `DASHBOARD_START` | `LayoutRenderHook` | Start of the dashboard page |
+| `DASHBOARD_END` | `LayoutRenderHook` | End of the dashboard page |
+| `ACCOUNT_START` | `LayoutRenderHook` | Before the account page content |
+| `ACCOUNT_END` | `LayoutRenderHook` | After the account page content |
+| `SETTINGS_INDEX_START` | `LayoutRenderHook` | Before the settings grid |
+| `SETTINGS_INDEX_END` | `LayoutRenderHook` | After the settings grid |
+
+#### Products
+
+| Constant | Class | Description |
+|----------|-------|-------------|
+| `INDEX_TABLE_BEFORE` | `ProductRenderHook` | Before the products table |
+| `INDEX_TABLE_AFTER` | `ProductRenderHook` | After the products table |
+| `EDIT_HEADER_AFTER` | `ProductRenderHook` | After the product edit page heading |
+| `EDIT_TABS_BEFORE` | `ProductRenderHook` | Before the product edit tabs |
+| `EDIT_TABS_END` | `ProductRenderHook` | Before the closing of the product edit tabs |
+| `EDIT_CONTENT_BEFORE` | `ProductRenderHook` | Before the product edit tab content |
+| `EDIT_CONTENT_AFTER` | `ProductRenderHook` | After the product edit tab content |
+| `VARIANT_HEADER_AFTER` | `ProductRenderHook` | After the variant page heading |
+| `VARIANT_MAIN_AFTER` | `ProductRenderHook` | After the variant main column |
+| `VARIANT_SIDEBAR_AFTER` | `ProductRenderHook` | After the variant sidebar column |
+
+#### Orders
+
+| Constant | Class | Description |
+|----------|-------|-------------|
+| `INDEX_TABLE_BEFORE` | `OrderRenderHook` | Before the orders table |
+| `INDEX_TABLE_AFTER` | `OrderRenderHook` | After the orders table |
+| `DETAIL_HEADER_AFTER` | `OrderRenderHook` | After the order detail sticky header |
+| `DETAIL_MAIN_BEFORE` | `OrderRenderHook` | Before the order detail main content |
+| `DETAIL_MAIN_AFTER` | `OrderRenderHook` | After the order detail main column |
+| `DETAIL_SIDEBAR_BEFORE` | `OrderRenderHook` | Before the order detail sidebar |
+| `DETAIL_SIDEBAR_AFTER` | `OrderRenderHook` | After the order detail sidebar |
+| `SHIPMENTS_TABLE_BEFORE` | `OrderRenderHook` | Before the shipments table |
+| `SHIPMENTS_TABLE_AFTER` | `OrderRenderHook` | After the shipments table |
+| `ABANDONED_CARTS_TABLE_BEFORE` | `OrderRenderHook` | Before the abandoned carts table |
+| `ABANDONED_CARTS_TABLE_AFTER` | `OrderRenderHook` | After the abandoned carts table |
+
+#### Customers
+
+| Constant | Class | Description |
+|----------|-------|-------------|
+| `INDEX_TABLE_BEFORE` | `CustomerRenderHook` | Before the customers table |
+| `INDEX_TABLE_AFTER` | `CustomerRenderHook` | After the customers table |
+| `CREATE_FORM_BEFORE` | `CustomerRenderHook` | Before the create customer form |
+| `CREATE_FORM_AFTER` | `CustomerRenderHook` | After the create customer form |
+| `SHOW_HEADER_AFTER` | `CustomerRenderHook` | After the customer show page header |
+| `SHOW_TABS_BEFORE` | `CustomerRenderHook` | Before the customer show tabs |
+| `SHOW_TABS_END` | `CustomerRenderHook` | Before the closing of the customer show tabs |
+| `SHOW_CONTENT_BEFORE` | `CustomerRenderHook` | Before the customer show tab content |
+| `SHOW_CONTENT_AFTER` | `CustomerRenderHook` | After the customer show tab content |
+
+#### Collections
+
+| Constant | Class | Description |
+|----------|-------|-------------|
+| `INDEX_TABLE_BEFORE` | `CollectionRenderHook` | Before the collections table |
+| `INDEX_TABLE_AFTER` | `CollectionRenderHook` | After the collections table |
+| `EDIT_FORM_BEFORE` | `CollectionRenderHook` | Before the collection edit form |
+| `EDIT_FORM_AFTER` | `CollectionRenderHook` | After the collection edit form |
+
+#### Catalog
+
+| Constant | Class | Description |
+|----------|-------|-------------|
+| `CATEGORIES_TABLE_BEFORE` | `CatalogRenderHook` | Before the categories table |
+| `CATEGORIES_TABLE_AFTER` | `CatalogRenderHook` | After the categories table |
+| `BRANDS_TABLE_BEFORE` | `CatalogRenderHook` | Before the brands table |
+| `BRANDS_TABLE_AFTER` | `CatalogRenderHook` | After the brands table |
+| `TAGS_TABLE_BEFORE` | `CatalogRenderHook` | Before the tags table |
+| `TAGS_TABLE_AFTER` | `CatalogRenderHook` | After the tags table |
+| `ATTRIBUTES_TABLE_BEFORE` | `CatalogRenderHook` | Before the attributes table |
+| `ATTRIBUTES_TABLE_AFTER` | `CatalogRenderHook` | After the attributes table |
+| `REVIEWS_TABLE_BEFORE` | `CatalogRenderHook` | Before the reviews table |
+| `REVIEWS_TABLE_AFTER` | `CatalogRenderHook` | After the reviews table |
+
+#### Sales
+
+| Constant | Class | Description |
+|----------|-------|-------------|
+| `DISCOUNTS_TABLE_BEFORE` | `SalesRenderHook` | Before the discounts table |
+| `DISCOUNTS_TABLE_AFTER` | `SalesRenderHook` | After the discounts table |
+| `SUPPLIERS_TABLE_BEFORE` | `SalesRenderHook` | Before the suppliers table |
+| `SUPPLIERS_TABLE_AFTER` | `SalesRenderHook` | After the suppliers table |
 
 ### Example: Wire Elements Modal
 
 ```php
 use Illuminate\Support\Facades\Blade;
-use Shopper\Enum\RenderHook;
 use Shopper\Facades\Shopper;
+use Shopper\View\LayoutRenderHook;
 
 Shopper::renderHook(
-    RenderHook::BodyEnd,
+    LayoutRenderHook::BODY_END,
     fn (): string => Blade::render('@livewire("wire-elements-modal")'),
 );
 ```
@@ -245,22 +358,22 @@ Shopper::renderHook(
 
 ```php
 use Illuminate\Support\Facades\Blade;
-use Shopper\Enum\RenderHook;
 use Shopper\Facades\Shopper;
+use Shopper\View\LayoutRenderHook;
 
-Shopper::renderHook(RenderHook::HeadEnd, fn (): string => Blade::render('@fluxStyles'))
-    ->renderHook(RenderHook::BodyEnd, fn (): string => Blade::render('@fluxScripts'));
+Shopper::renderHook(LayoutRenderHook::HEAD_END, fn (): string => Blade::render('@fluxStyles'))
+    ->renderHook(LayoutRenderHook::BODY_END, fn (): string => Blade::render('@fluxScripts'));
 ```
 
 ### Example: Laravel Notify
 
 ```php
 use Illuminate\Support\Facades\Blade;
-use Shopper\Enum\RenderHook;
 use Shopper\Facades\Shopper;
+use Shopper\View\LayoutRenderHook;
 
 Shopper::renderHook(
-    RenderHook::BodyEnd,
+    LayoutRenderHook::BODY_END,
     fn (): string => Blade::render('<x-notify::notify />'),
 );
 ```

--- a/v2/extending/control-panel.mdx
+++ b/v2/extending/control-panel.mdx
@@ -123,7 +123,7 @@ public function boot(): void
 
 ### Branding Logo
 
-By default, the Laravel Shopper logo is used on the login page and in the sidebar header. You have several options to replace it with your own brand.
+By default, the Shopper logo is used on the login page and in the sidebar header. You have several options to replace it with your own brand.
 
 #### Via configuration
 

--- a/v2/getting-started.mdx
+++ b/v2/getting-started.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Introduction"
-description: "Laravel Shopper is a Headless CMS that provides modular tools for creating unique e-commerce experiences"
+description: "Shopper is a Headless CMS that provides modular tools for creating unique e-commerce experiences"
 ---
 
 Shopper is a Headless CMS how provide a range collection of modular tools and components designed to help developers create unique and powerful e-commerce experiences.

--- a/v2/installation.mdx
+++ b/v2/installation.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Installation"
-description: "Quick start guide for installing and configuring Laravel Shopper on your existing Laravel App"
+description: "Quick start guide for installing and configuring Shopper on your existing Laravel App"
 ---
 
 ## Supported Versions of Laravel

--- a/v2/livewire-starter-kit.mdx
+++ b/v2/livewire-starter-kit.mdx
@@ -27,7 +27,7 @@ application so that you have full control and visibility over its features and i
 
 ## Structure
 
-When you install the Laravel Shopper Livewire Starter Kit, the following directories and files are published to your application. 
+When you install the Shopper Livewire Starter Kit, the following directories and files are published to your application. 
 This structure provides simplest foundation for building your e-commerce storefront while giving you full control over customization.
 
 ### Actions

--- a/v2/orders.mdx
+++ b/v2/orders.mdx
@@ -429,12 +429,12 @@ use Shopper\Core\Events\Orders\OrderCreated;
 use Shopper\Core\Events\Orders\OrderPaid;
 use Shopper\Core\Events\Orders\OrderShipped;
 use Shopper\Core\Events\Orders\OrderCompleted;
-use Shopper\Core\Events\Orders\OrderCancel;
+use Shopper\Core\Events\Orders\OrderCancelled;
 use Shopper\Core\Events\Orders\OrderArchived;
 use Shopper\Core\Events\Orders\OrderDeleted;
 use Shopper\Core\Events\Orders\OrderShipmentCreated;
 use Shopper\Core\Events\Orders\OrderShipmentDelivered;
-use Shopper\Core\Events\Orders\AddNoteToOrder;
+use Shopper\Core\Events\Orders\OrderNoteAdded;
 ```
 
 For the full events reference including shipment events, payload details, and usage examples, see the [Events](/v2/events#order-events) page.

--- a/v2/reference/typescript-types.mdx
+++ b/v2/reference/typescript-types.mdx
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Official TypeScript type definitions for Laravel Shopper models and entities.
+description: Official TypeScript type definitions for Shopper models and entities.
 ---
 
 The `@shopperlabs/shopper-types` package provides comprehensive TypeScript type definitions for all Shopper models and entities. These types are useful when building storefronts, mobile apps, or any TypeScript application that interacts with the Shopper API.

--- a/v2/render-hooks.mdx
+++ b/v2/render-hooks.mdx
@@ -1,0 +1,246 @@
+---
+title: Render Hooks
+description: Inject custom HTML, Livewire components, or Blade views into specific positions across the admin panel without modifying Shopper's core views.
+---
+
+Render hooks give you named injection points inside Shopper's admin views. Instead of overriding templates, you register a callback on a hook name and Shopper renders your content in the right place at the right time.
+
+This is the recommended way to extend any admin page adding a custom banner to the order detail sidebar, inserting a widget above the product list, or injecting tracking scripts into the page head.
+
+## Registering a Hook
+
+Hooks are registered on the `ShopperPanel` instance via the `Shopper` facade. The recommended place to register them is in the `boot()` method of your application's service provider or in a dedicated extension service provider.
+
+```php
+use Shopper\Facades\Shopper;
+use Shopper\View\OrderRenderHook;
+
+Shopper::renderHook(
+    OrderRenderHook::DETAIL_SIDEBAR_AFTER,
+    fn (): string => view('orders.custom-sidebar-widget')->render(),
+);
+```
+
+The callback receives no arguments and must return a `string`. You can return any HTML, a rendered Blade view, or a Livewire component tag.
+
+### Returning a Blade View
+
+```php
+use Shopper\Facades\Shopper;
+use Shopper\View\ProductRenderHook;
+
+Shopper::renderHook(
+    ProductRenderHook::EDIT_CONTENT_AFTER,
+    fn (): string => view('products.seo-panel')->render(),
+);
+```
+
+### Returning a Livewire Component
+
+```php
+use Shopper\Facades\Shopper;
+use Shopper\View\CustomerRenderHook;
+
+Shopper::renderHook(
+    CustomerRenderHook::SHOW_TABS_END,
+    fn (): string => '<livewire:customer-loyalty-tab />',
+);
+```
+
+### Registering Multiple Hooks
+
+You can chain multiple `renderHook()` calls on the same `Shopper` instance:
+
+```php
+use Shopper\Facades\Shopper;
+use Shopper\View\LayoutRenderHook;
+
+Shopper::renderHook(
+    LayoutRenderHook::HEAD_END,
+    fn (): string => '<script src="https://cdn.example.com/analytics.js" defer></script>',
+);
+
+Shopper::renderHook(
+    LayoutRenderHook::BODY_START,
+    fn (): string => view('analytics.noscript-tag')->render(),
+);
+```
+
+Multiple callbacks registered on the same hook are rendered in the order they were registered, concatenated together.
+
+## Disabling a Hook
+
+Hooks registered from an addon respect the addon's enabled state they are never registered when the addon is disabled. For application-level hooks, you can conditionally register them:
+
+```php
+if (config('features.custom_order_widget')) {
+    Shopper::renderHook(
+        OrderRenderHook::DETAIL_MAIN_AFTER,
+        fn (): string => view('orders.external-status')->render(),
+    );
+}
+```
+
+## Available Hooks
+
+### Layout Hooks
+
+`LayoutRenderHook` covers the global admin layout present on every page.
+
+| Constant | Hook Name | Position |
+|----------|-----------|----------|
+| `HEAD_START` | `shopper::head.start` | Immediately after `<head>` |
+| `HEAD_END` | `shopper::head.end` | Immediately before `</head>` |
+| `BODY_START` | `shopper::body.start` | Immediately after `<body>` |
+| `BODY_END` | `shopper::body.end` | Immediately before `</body>` |
+| `HEADER_START` | `shopper::header.start` | Start of the top navigation bar |
+| `HEADER_END` | `shopper::header.end` | End of the top navigation bar |
+| `CONTENT_START` | `shopper::content.start` | Before the main page content area |
+| `CONTENT_END` | `shopper::content.end` | After the main page content area |
+| `DASHBOARD_START` | `shopper::dashboard.start` | Top of the dashboard page |
+| `DASHBOARD_END` | `shopper::dashboard.end` | Bottom of the dashboard page |
+| `ACCOUNT_START` | `shopper::account.start` | Top of the account/profile page |
+| `ACCOUNT_END` | `shopper::account.end` | Bottom of the account/profile page |
+| `SETTINGS_INDEX_START` | `shopper::settings.index.start` | Top of the settings index page |
+| `SETTINGS_INDEX_END` | `shopper::settings.index.end` | Bottom of the settings index page |
+
+### Product Hooks
+
+`ProductRenderHook` targets the product list and product edit pages.
+
+| Constant | Hook Name | Position |
+|----------|-----------|----------|
+| `INDEX_TABLE_BEFORE` | `shopper::products.index.table.before` | Above the products table |
+| `INDEX_TABLE_AFTER` | `shopper::products.index.table.after` | Below the products table |
+| `EDIT_HEADER_AFTER` | `shopper::product.edit.header.after` | Below the product page header |
+| `EDIT_TABS_BEFORE` | `shopper::product.edit.tabs.before` | Before the edit page tabs |
+| `EDIT_TABS_END` | `shopper::product.edit.tabs.end` | After the last edit page tab (use to add new tabs) |
+| `EDIT_CONTENT_BEFORE` | `shopper::product.edit.content.before` | Before the active tab content |
+| `EDIT_CONTENT_AFTER` | `shopper::product.edit.content.after` | After the active tab content |
+| `VARIANT_HEADER_AFTER` | `shopper::product.variant.header.after` | Below the variant page header |
+| `VARIANT_MAIN_AFTER` | `shopper::product.variant.main.after` | After the variant main content area |
+| `VARIANT_SIDEBAR_AFTER` | `shopper::product.variant.sidebar.after` | After the variant sidebar |
+
+### Order Hooks
+
+`OrderRenderHook` targets the order list, order detail, shipments, and abandoned carts pages.
+
+| Constant | Hook Name | Position |
+|----------|-----------|----------|
+| `INDEX_TABLE_BEFORE` | `shopper::orders.index.table.before` | Above the orders table |
+| `INDEX_TABLE_AFTER` | `shopper::orders.index.table.after` | Below the orders table |
+| `DETAIL_HEADER_AFTER` | `shopper::order.detail.header.after` | Below the order detail page header |
+| `DETAIL_MAIN_BEFORE` | `shopper::order.detail.main.before` | Before the main content column |
+| `DETAIL_MAIN_AFTER` | `shopper::order.detail.main.after` | After the main content column |
+| `DETAIL_SIDEBAR_BEFORE` | `shopper::order.detail.sidebar.before` | Before the sidebar column |
+| `DETAIL_SIDEBAR_AFTER` | `shopper::order.detail.sidebar.after` | After the sidebar column |
+| `SHIPMENTS_TABLE_BEFORE` | `shopper::shipments.index.table.before` | Above the shipments table |
+| `SHIPMENTS_TABLE_AFTER` | `shopper::shipments.index.table.after` | Below the shipments table |
+| `ABANDONED_CARTS_TABLE_BEFORE` | `shopper::abandoned-carts.table.before` | Above the abandoned carts table |
+| `ABANDONED_CARTS_TABLE_AFTER` | `shopper::abandoned-carts.table.after` | Below the abandoned carts table |
+
+### Customer Hooks
+
+`CustomerRenderHook` targets the customer list and customer detail pages.
+
+| Constant | Hook Name | Position |
+|----------|-----------|----------|
+| `INDEX_TABLE_BEFORE` | `shopper::customers.index.table.before` | Above the customers table |
+| `INDEX_TABLE_AFTER` | `shopper::customers.index.table.after` | Below the customers table |
+| `CREATE_FORM_BEFORE` | `shopper::customer.create.form.before` | Before the new customer form |
+| `CREATE_FORM_AFTER` | `shopper::customer.create.form.after` | After the new customer form |
+| `SHOW_HEADER_AFTER` | `shopper::customer.show.header.after` | Below the customer detail header |
+| `SHOW_TABS_BEFORE` | `shopper::customer.show.tabs.before` | Before the customer detail tabs |
+| `SHOW_TABS_END` | `shopper::customer.show.tabs.end` | After the last customer tab (use to add new tabs) |
+| `SHOW_CONTENT_BEFORE` | `shopper::customer.show.content.before` | Before the active tab content |
+| `SHOW_CONTENT_AFTER` | `shopper::customer.show.content.after` | After the active tab content |
+
+### Collection Hooks
+
+`CollectionRenderHook` targets the collection list and collection edit pages.
+
+| Constant | Hook Name | Position |
+|----------|-----------|----------|
+| `INDEX_TABLE_BEFORE` | `shopper::collections.index.table.before` | Above the collections table |
+| `INDEX_TABLE_AFTER` | `shopper::collections.index.table.after` | Below the collections table |
+| `EDIT_FORM_BEFORE` | `shopper::collection.edit.form.before` | Before the collection edit form |
+| `EDIT_FORM_AFTER` | `shopper::collection.edit.form.after` | After the collection edit form |
+
+### Catalog Hooks
+
+`CatalogRenderHook` covers the catalog support pages: categories, brands, tags, attributes, and reviews.
+
+| Constant | Hook Name | Position |
+|----------|-----------|----------|
+| `CATEGORIES_TABLE_BEFORE` | `shopper::categories.index.table.before` | Above the categories table |
+| `CATEGORIES_TABLE_AFTER` | `shopper::categories.index.table.after` | Below the categories table |
+| `BRANDS_TABLE_BEFORE` | `shopper::brands.index.table.before` | Above the brands table |
+| `BRANDS_TABLE_AFTER` | `shopper::brands.index.table.after` | Below the brands table |
+| `TAGS_TABLE_BEFORE` | `shopper::tags.index.table.before` | Above the tags table |
+| `TAGS_TABLE_AFTER` | `shopper::tags.index.table.after` | Below the tags table |
+| `ATTRIBUTES_TABLE_BEFORE` | `shopper::attributes.index.table.before` | Above the attributes table |
+| `ATTRIBUTES_TABLE_AFTER` | `shopper::attributes.index.table.after` | Below the attributes table |
+| `REVIEWS_TABLE_BEFORE` | `shopper::reviews.index.table.before` | Above the reviews table |
+| `REVIEWS_TABLE_AFTER` | `shopper::reviews.index.table.after` | Below the reviews table |
+
+### Sales Hooks
+
+`SalesRenderHook` covers the discounts and suppliers pages.
+
+| Constant | Hook Name | Position |
+|----------|-----------|----------|
+| `DISCOUNTS_TABLE_BEFORE` | `shopper::discounts.index.table.before` | Above the discounts table |
+| `DISCOUNTS_TABLE_AFTER` | `shopper::discounts.index.table.after` | Below the discounts table |
+| `SUPPLIERS_TABLE_BEFORE` | `shopper::suppliers.index.table.before` | Above the suppliers table |
+| `SUPPLIERS_TABLE_AFTER` | `shopper::suppliers.index.table.after` | Below the suppliers table |
+
+## Example: Injecting an External Status Badge on Order Detail
+
+A real-world scenario: your store syncs orders to a fulfillment service (ShipStation, ShipBob, etc.) and you want to display the external status directly on the order detail page, without modifying any Shopper files.
+
+Create a Livewire component:
+
+```php
+use Livewire\Component;
+use Livewire\Attributes\Locked;
+
+final class ExternalOrderStatus extends Component
+{
+    #[Locked]
+    public int $orderId;
+
+    public function render(): \Illuminate\Contracts\View\View
+    {
+        $status = ExternalFulfillmentService::getStatus($this->orderId);
+
+        return view('livewire.external-order-status', ['status' => $status]);
+    }
+}
+```
+
+Register the hook in your service provider:
+
+```php
+use Shopper\Facades\Shopper;
+use Shopper\View\OrderRenderHook;
+
+public function boot(): void
+{
+    Shopper::renderHook(
+        OrderRenderHook::DETAIL_SIDEBAR_AFTER,
+        fn (): string => '<livewire:external-order-status :order-id="$order->id" />',
+    );
+}
+```
+
+## Using Hook Constants vs. Raw Strings
+
+Always use the class constants instead of raw hook name strings. They are checked by static analysis, will trigger IDE autocompletion, and won't silently break if a hook name changes in a future release.
+
+```php
+use Shopper\View\ProductRenderHook;
+
+Shopper::renderHook(ProductRenderHook::EDIT_CONTENT_AFTER, fn () => '...');
+
+Shopper::renderHook('shopper::product.edit.content.after', fn () => '...');
+```

--- a/v2/requirements.mdx
+++ b/v2/requirements.mdx
@@ -1,13 +1,13 @@
 ---
 title: "Requirements"
-description: "Server requirements for running Laravel Shopper"
+description: "Server requirements for running Shopper"
 ---
 
 Shopper is a modern PHP application, built as a [Laravel](https://laravel.com) package, and has the same server requirements as &mdash; you guessed it &mdash; Laravel itself. To manipulate images (resize, crop, etc), you will also need the GD Library or ImageMagick.
 
 ## Requirements
 
-To run Laravel Shopper you'll need a server meeting the following requirements:
+To run Shopper you'll need a server meeting the following requirements:
 
 - PHP 8.3+
 - Laravel 11.x

--- a/v2/sidebar/overview.mdx
+++ b/v2/sidebar/overview.mdx
@@ -50,7 +50,7 @@ You can use this package in any Laravel application to create custom sidebars. S
 
 ### Extending Shopper
 
-If you're using Laravel Shopper, you can extend the admin panel sidebar using the event-based system. See [Extending Shopper Navigation](/v2/sidebar/shopper-extension) for details.
+If you're using Shopper, you can extend the admin panel sidebar using the event-based system. See [Extending Shopper Navigation](/v2/sidebar/shopper-extension) for details.
 
 ## Requirements
 

--- a/v2/starter-kits.mdx
+++ b/v2/starter-kits.mdx
@@ -19,7 +19,7 @@ or leveraging the starter kit, Shopper empowers you to deliver e-commerce experi
 
 ## Quickstart
 
-To help you get started quickly and efficiently, Laravel Shopper offers three starter kits, each built on the same stacks as Laravel Breeze:
+To help you get started quickly and efficiently, Shopper offers three starter kits, each built on the same stacks as Laravel Breeze:
 [Blade](https://laravel.com/v2/blade), [Livewire](https://livewire.laravel.com/), and [Inertia](https://inertiajs.com/). These kits are designed
 to streamline your development process while giving you the flexibility to choose the stack that best suits your project needs.
 
@@ -63,9 +63,9 @@ specific prerequisites will be added to get the project off the ground.
 
 ## Installation
 
-The Starter Kit requires a Shopper backend to be installed and running to work. Laravel Shopper is a headless e-commerce framework,
+The Starter Kit requires a Shopper backend to be installed and running to work. Shopper is a headless e-commerce framework,
 so storefronts connect to it to provide commerce features to customers. This setup allows you to build a fully customizable frontend while
-leveraging the powerful backend capabilities of Laravel Shopper.
+leveraging the powerful backend capabilities of Shopper.
 
 ```shell
 composer require shopper/starter-kits --dev
@@ -91,7 +91,7 @@ issues, we strongly recommend using the starter kits only with new projects.
 
 ## Features
 
-The Laravel Shopper Starter Kit provides a foundation for building modern e-commerce storefronts. Here are some of the key features
+The Shopper Starter Kit provides a foundation for building modern e-commerce storefronts. Here are some of the key features
 
 
 ### Collections
@@ -119,7 +119,7 @@ Your store's products are showcased on the homepage. If you don't see any produc
 
 ### Authentication
 
-The entire authentication system is built directly into the Laravel Shopper Starter Kit, so you don't need to install [Laravel Breeze](https://github.com/laravel/breeze) separately.
+The entire authentication system is built directly into the Shopper Starter Kit, so you don't need to install [Laravel Breeze](https://github.com/laravel/breeze) separately.
 The starter kit is inspired by `Breeze`, providing the authentication system, including user registration, login, password reset, and account management.
 
 <Frame caption="Login screen">

--- a/v2/taxes.mdx
+++ b/v2/taxes.mdx
@@ -1,0 +1,381 @@
+---
+title: Taxes
+description: Configure tax zones, rates, and override rules to calculate taxes accurately per region, VAT-inclusive or sales-tax-exclusive.
+---
+
+Shopper calculates taxes per line item, based on where an order is being shipped. You define geographic zones, assign percentage rates to each zone, and optionally override those rates for specific products, product types, or categories. The cart pipeline applies all of this automatically during checkout.
+
+All tax amounts are stored in **cents** as unsigned integers, consistent with the rest of the monetary system.
+
+## How It Works
+
+The tax system has four main pieces:
+
+1. **TaxZone**: a geographic area (country, or country + province) with a tax inclusion policy and an optional custom provider
+2. **TaxRate**: a percentage rate attached to a zone; one rate per zone is marked as the default
+3. **TaxRateRule**: a targeting rule on a rate; when a cart line matches a rule, its rate takes priority over the zone's default
+4. **TaxCalculationProvider**: the service responsible for receiving a taxable item and a context, and returning `TaxLine` value objects
+
+When the cart is being calculated, the `CalculateTax` pipeline step reads the shipping address, resolves the matching `TaxZone`, picks the applicable `TaxRate`, and persists a `CartLineTaxLine` record for every cart line with a non-zero tax amount.
+
+## Tax Zones
+
+A tax zone defines where a tax configuration applies. It maps to a country and optionally to a specific province or state within that country. The most important setting on a zone is `is_tax_inclusive`, which determines whether prices already include tax (VAT, common in Europe) or whether tax is added on top (sales tax, common in the US).
+
+```php
+use Shopper\Core\Models\Country;
+use Shopper\Core\Models\TaxZone;
+
+$france = Country::query()->where('cca2', 'FR')->firstOrFail();
+
+TaxZone::query()->create([
+    'country_id' => $france->id,
+    'name' => 'Standard VAT',
+    'is_tax_inclusive' => true,
+]);
+```
+
+```php
+$usa = Country::query()->where('cca2', 'US')->firstOrFail();
+
+TaxZone::query()->create([
+    'country_id' => $usa->id,
+    'province_code' => 'CA',
+    'name' => 'California Sales Tax',
+    'is_tax_inclusive' => false,
+]);
+```
+
+When the calculator resolves a zone for a shipping address, it first tries to find a zone matching both the country and province. If none exists, it falls back to a country-level zone with no `province_code`.
+
+The `display_name` accessor produces a human-readable label by combining country and zone name: `France — Standard VAT`.
+
+### Zone Schema
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `country_id` | `unsignedBigInteger` | The country this zone applies to |
+| `province_code` | `nullable string` | ISO province/state code (`CA`, `NY`, `IDF`) |
+| `name` | `nullable string` | Optional label to identify the zone in the admin |
+| `is_tax_inclusive` | `boolean` | Whether prices already include tax (VAT) or not (sales tax) |
+| `provider_id` | `nullable unsignedBigInteger` | Custom tax provider; falls back to the system default when null |
+| `parent_id` | `nullable unsignedBigInteger` | Parent zone for hierarchical configurations |
+| `metadata` | `nullable jsonb` | Arbitrary data for custom providers |
+
+The combination of `country_id` and `province_code` is unique, you cannot have two zones for the same country/province pair.
+
+### Zone Relationships
+
+| Relationship | Type | Description |
+|---|---|---|
+| `country()` | `BelongsTo` | The country this zone is scoped to |
+| `rates()` | `HasMany` | All tax rates defined for this zone |
+| `provider()` | `BelongsTo` | The custom tax provider assigned to this zone |
+| `parent()` | `BelongsTo` | Parent zone |
+| `children()` | `HasMany` | Child zones |
+
+## Tax Rates
+
+Each zone has one or more rates. One rate should be marked as `is_default` it applies to every item in the zone that does not match a more specific override rule.
+
+```php
+use Shopper\Core\Models\TaxRate;
+
+TaxRate::query()->create([
+    'tax_zone_id' => $franceZone->id,
+    'name' => 'TVA 20%',
+    'code' => 'FR_VAT_STANDARD',
+    'rate' => 20.0,
+    'is_default'  => true,
+]);
+```
+
+France has a reduced VAT rate of 5.5% on food. You can define it as a separate non-default rate on the same zone, then target it at the right product category using a rule:
+
+```php
+TaxRate::query()->create([
+    'tax_zone_id' => $franceZone->id,
+    'name' => 'TVA reduce 5.5%',
+    'code' => 'FR_VAT_REDUCED',
+    'rate' => 5.5,
+    'is_default' => false,
+]);
+```
+
+### Tax Rate Schema
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `tax_zone_id` | `unsignedBigInteger` | The zone this rate belongs to |
+| `name` | `string` | Display name shown on invoices (`TVA 20%`) |
+| `code` | `nullable string` | Machine-readable identifier (`FR_VAT_STANDARD`) |
+| `rate` | `decimal(8,4)` | Percentage value `20.0` means 20% |
+| `is_default` | `boolean` | Applied when no override rule matches the item |
+| `is_combinable` | `boolean` | Whether this rate stacks with rates from a parent zone |
+| `metadata` | `nullable jsonb` | Arbitrary data for external providers |
+
+### Rate Relationships
+
+| Relationship | Type | Description |
+|---|---|---|
+| `taxZone()` | `BelongsTo` | The zone this rate is attached to |
+| `rules()` | `HasMany` | Override rules that activate this rate for specific items |
+
+## Tax Rate Rules
+
+Rules let you override the default rate for specific items. The calculator checks all non-default rates with rules first. The first rule that matches the cart line wins; if none matches, the zone's default rate is used.
+
+A rule has two fields: `reference_type` identifies what kind of entity to match, and `reference_id` holds the specific value to match against.
+
+```php
+use Shopper\Core\Models\TaxRateRule;
+
+TaxRateRule::query()->create([
+    'tax_rate_id' => $reducedRate->id,
+    'reference_type' => 'category',
+    'reference_id' => (string) $foodCategory->id,
+]);
+```
+
+This rule tells the calculator: "whenever a cart line belongs to the food category, use the 5.5% rate instead of the default 20%."
+
+You can also target a specific product:
+
+```php
+TaxRateRule::query()->create([
+    'tax_rate_id' => $zeroVatRate->id,
+    'reference_type' => 'product',
+    'reference_id' => (string) $childrenBook->id,
+]);
+```
+
+Or an entire product type — useful for applying different rules to virtual goods versus physical ones:
+
+```php
+TaxRateRule::query()->create([
+    'tax_rate_id' => $digitalRate->id,
+    'reference_type' => 'product_type',
+    'reference_id' => 'virtual',
+]);
+```
+
+### Rule Reference Types
+
+| `reference_type` | `reference_id` | Matches when |
+|---|---|---|
+| `product_type` | A `ProductType` enum value (`standard`, `virtual`, `external`) | The item's product type equals the value |
+| `product` | A product primary key, as a string | The item's exact product ID matches |
+| `category` | A category primary key, as a string | The item belongs to that category |
+
+The combination of `tax_rate_id`, `reference_type`, and `reference_id` is unique you cannot attach the same rule twice to the same rate.
+
+## Inclusive vs Exclusive Taxes
+
+The `is_tax_inclusive` flag on the zone controls the math behind the tax amount.
+
+**Tax-exclusive** (sales tax): tax is added on top of the price. The customer pays more than the listed price:
+
+```
+tax = unit_price × rate / 100
+total = unit_price + tax
+```
+
+A $100 product with a 10% exclusive tax costs **$110** at checkout.
+
+**Tax-inclusive** (VAT): tax is already embedded in the listed price. The customer pays exactly the listed price, but the tax authority receives a portion:
+
+```
+tax = price − (price / (1 + rate / 100))
+total = price (unchanged)
+```
+
+A €100 product with 20% VAT inclusive: tax = €100 - (€100 / 1.2) = **€16.67**, amount before tax = **€83.33**.
+
+Shopper handles both formulas automatically in `SystemTaxProvider`. The zone's `is_tax_inclusive` value is also propagated through the pipeline context so storefronts can present prices correctly showing "VAT included" or displaying tax as an addition at checkout.
+
+## Cart Integration
+
+Tax calculation is part of the cart pipeline and runs automatically whenever you call `Cart::calculate()`. The `CalculateTax` step runs after discounts are applied, ensuring taxes are computed on the post-discount amount.
+
+The step does the following for each cart line:
+
+1. Reads the cart's shipping address country and province
+2. Builds a `TaxCalculationContext` from those values
+3. Passes a `CartLineTaxAdapter` for the line to `TaxCalculator::calculate()`
+4. Deletes any existing `CartLineTaxLine` records for that line
+5. Creates new `CartLineTaxLine` records with the resulting tax lines
+6. Accumulates the tax total on the pipeline context
+
+```php
+use Shopper\Cart\Facades\Cart;
+
+$cart = Cart::calculate($cart);
+
+$cart->tax_amount;
+
+foreach ($cart->lines as $line) {
+    $line->taxLines;
+}
+```
+
+If no matching tax zone exists for the shipping address, the `CalculateTax` step skips silently and no tax lines are created.
+
+## Persisting Tax Lines on Orders
+
+When a cart is converted into an order, tax lines are snapshotted onto the order using `CreateOrderTaxLinesAction`. This snapshot preserves the exact tax breakdown at the moment of purchase future changes to zones or rates have no impact on historical orders.
+
+```php
+use Shopper\Core\Actions\CreateOrderTaxLinesAction;
+
+app(CreateOrderTaxLinesAction::class)->execute($order);
+```
+
+The action resolves the shipping address country, runs `TaxCalculator::calculate()` for each order item, creates an `OrderTaxLine` record for each result, and updates `tax_amount` on both the order item and the order itself.
+
+### OrderTaxLine Schema
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `taxable_type` | `string` | Polymorphic type (`Order` or `OrderItem`) |
+| `taxable_id` | `unsignedBigInteger` | Polymorphic ID |
+| `tax_rate_id` | `nullable unsignedBigInteger` | Reference to the rate used at time of purchase |
+| `code` | `string` | Rate code snapshot |
+| `name` | `string` | Rate name snapshot |
+| `rate` | `decimal(8,4)` | Rate percentage snapshot |
+| `amount` | `unsignedInteger` | Tax amount in cents |
+
+### Accessing Tax Lines on an Order
+
+```php
+use Shopper\Core\Models\Contracts\Order;
+
+$order = resolve(Order::class)::query()
+    ->with(['items.taxLines', 'taxLines'])
+    ->find($orderId);
+
+$order->tax_amount;
+
+foreach ($order->items as $item) {
+    $item->tax_amount;
+
+    foreach ($item->taxLines as $taxLine) {
+        $taxLine->name;
+        $taxLine->rate;
+        $taxLine->amount;
+    }
+}
+```
+
+## Custom Tax Providers
+
+The built-in `SystemTaxProvider` handles most use cases. For regions that require an external API like Avalara, TaxJar, or a homegrown tax service, you can implement the `TaxCalculationProvider` contract and assign it to specific zones.
+
+The contract is simple:
+
+```php
+use Shopper\Core\Contracts\TaxCalculationProvider;
+use Shopper\Core\Contracts\TaxableItem;
+use Shopper\Core\Taxes\TaxCalculationContext;
+use Shopper\Core\Taxes\TaxLine;
+
+interface TaxCalculationProvider
+{
+    public function identifier(): string;
+
+    /** @return array<int, TaxLine> */
+    public function getTaxLines(TaxableItem $item, TaxCalculationContext $context): array;
+}
+```
+
+Here is a complete implementation that calls a fictional external tax API:
+
+```php
+use Shopper\Core\Contracts\TaxCalculationProvider;
+use Shopper\Core\Contracts\TaxableItem;
+use Shopper\Core\Taxes\TaxCalculationContext;
+use Shopper\Core\Taxes\TaxLine;
+
+final class AvalaraTaxProvider implements TaxCalculationProvider
+{
+    public function __construct(
+        private readonly AvalartaClient $client,
+    ) {}
+
+    public function identifier(): string
+    {
+        return 'avalara';
+    }
+
+    public function getTaxLines(TaxableItem $item, TaxCalculationContext $context): array
+    {
+        $response = $this->client->calculate(
+            amount: $item->getTaxableAmount() * $item->getQuantity(),
+            countryCode: $context->countryCode,
+            provinceCode: $context->provinceCode,
+        );
+
+        return [
+            new TaxLine(
+                taxRateId: 0,
+                name: $response->description,
+                code: $response->jurisdictionCode,
+                rate: $response->rate,
+                amount: $response->taxAmountInCents,
+            ),
+        ];
+    }
+}
+```
+
+Register the provider in your service provider:
+
+```php
+use Shopper\Core\Contracts\TaxCalculationProvider;
+
+$this->app->bind(TaxCalculationProvider::class, AvalaraTaxProvider::class);
+```
+
+Then create a `TaxProvider` record and link it to the zone that should use it:
+
+```php
+use Shopper\Core\Models\TaxProvider;
+
+$provider = TaxProvider::query()->create([
+    'identifier' => 'avalara',
+    'is_enabled' => true,
+]);
+
+$usZone->update(['provider_id' => $provider->id]);
+```
+
+When the calculator resolves a zone that has an enabled provider, it instantiates that provider from the container instead of falling back to the system default. Each unique country/province combination is cached in memory for the duration of the request, so the provider is only resolved once per zone.
+
+### The TaxCalculationContext
+
+The `TaxCalculationContext` is a read-only value object that carries the geographic information needed to resolve the correct zone and provider:
+
+| Property | Type | Description |
+|---|---|---|
+| `countryCode` | `string` | ISO 3166-1 alpha-2 country code (`FR`, `US`, `DE`) |
+| `provinceCode` | `?string` | ISO province/state code (`CA`, `NY`) |
+| `customerId` | `?int` | The authenticated customer's ID, for future customer-level tax rules |
+| `resolvedZone` | `?TaxZone` | Pre-resolved zone; set internally by the calculator to avoid redundant queries |
+
+### The TaxableItem Contract
+
+Any object you pass to `TaxCalculator::calculate()` must implement `Shopper\Core\Contracts\TaxableItem`:
+
+| Method | Return | Description |
+|--------|--------|-------------|
+| `getTaxableAmount()` | `int` | Unit price in cents, after any item-level adjustments |
+| `getQuantity()` | `int` | Item quantity |
+| `getProductType()` | `?string` | Product type value (`standard`, `virtual`, `external`) |
+| `getProductId()` | `?int` | The product's primary key |
+| `getCategoryIds()` | `array<int, int>` | Primary keys of all categories the product belongs to |
+
+Shopper ships two ready-made adapters:
+
+- `CartLineTaxAdapter` wraps a `CartLine` for use during cart calculation; taxable amount is the post-discount line total divided by quantity
+- `OrderItemTaxAdapter` wraps an `OrderItem` for use in `CreateOrderTaxLinesAction`; taxable amount is the raw `unit_price_amount` in cents
+
+If you are building a custom checkout flow or need to calculate taxes outside of a cart, you can implement `TaxableItem` directly on any of your objects and call `TaxCalculator::calculate()` with a manually constructed `TaxCalculationContext`.

--- a/v2/upgrade.mdx
+++ b/v2/upgrade.mdx
@@ -11,6 +11,7 @@ If you're upgrading across multiple versions (e.g., v2.1 → v2.3), follow each 
 
 | Upgrade Path | Key Changes |
 |---|---|
+| [v2.5 → v2.6](/v2/upgrade/v2-5-to-v2-6) | Cart package, tax system, auth models moved, enum contracts, render hooks, addon system |
 | [v2.4 → v2.5](/v2/upgrade/v2-4-to-v2-5) | Three-status orders, payment drivers, shipment tracking |
 | [v2.2 → v2.3](/v2/upgrade/v2-2-to-v2-3) | Product Tags, new permissions |
 | [v2.1 → v2.2](/v2/upgrade/v2-1-to-v2-2) | Repository removal, Model Contracts, Filament v4, ShopperUser trait, sidebar redesign |

--- a/v2/upgrade/v2-1-to-v2-2.mdx
+++ b/v2/upgrade/v2-1-to-v2-2.mdx
@@ -447,20 +447,38 @@ The following features are deprecated and will be removed in v3.0:
 
 ## Migration Checklist
 
-Use this checklist to ensure a complete upgrade:
-
-- [ ] Update PHP to ^8.3
-- [ ] Update Laravel to ^11.0 or ^12.0
-- [ ] Update `composer.json` dependencies
-- [ ] Run `composer update`
-- [ ] Update `config/shopper/core.php`: rename `users` to `roles`
-- [ ] Update `config/shopper/models.php`: add `address`, `inventory`, `order`, `supplier`
-- [ ] Create new permissions for `reviews`, `product_variants`, and `suppliers`
-- [ ] Update `config/shopper/orders.php`: update generator configuration
-- [ ] Update User model to implement `ShopperUser` interface and trait
-- [ ] Replace repository usage with model contracts
-- [ ] Update custom button components to Filament buttons
-- [ ] Update custom modal components if overridden
-- [ ] Run `php artisan migrate`
-- [ ] Clear caches: `php artisan optimize:clear`
-- [ ] Test your application thoroughly
+<Steps>
+  <Step title="Update requirements">
+    Ensure your environment runs PHP ^8.3 and Laravel ^11.0 or ^12.0 before proceeding.
+  </Step>
+  <Step title="Update dependencies">
+    Update `shopper/framework` to `^2.2` in `composer.json`, then run `composer update -W`.
+  </Step>
+  <Step title="Run migrations">
+    Run `php artisan migrate` to apply all new migrations.
+  </Step>
+  <Step title="Rename `users` key to `roles` in config">
+    In `config/shopper/core.php`, rename the `users` key to `roles` and update its sub-keys (`admin_role` → `admin`, `default_role` → `user`).
+  </Step>
+  <Step title="Add new models to configuration">
+    In `config/shopper/models.php`, add the `address`, `inventory`, `order`, and `supplier` entries if you have a published config file.
+  </Step>
+  <Step title="Create new permissions">
+    Run `Permission::generate()` for `reviews`, `product_variants`, and `suppliers`, then assign the generated permissions to the `administrator` role.
+  </Step>
+  <Step title="Update order number generator configuration">
+    In `config/shopper/orders.php`, update the generator array to include the new `separator` and `date_format` keys.
+  </Step>
+  <Step title="Update User model">
+    Replace `extends ShopperUser` with `implements ShopperUserContract` and add `use ShopperUser` in your `App\Models\User` class.
+  </Step>
+  <Step title="Replace repository usage">
+    Replace all direct repository class usage with model contracts resolved via `resolve(ContractClass::class)` or direct model queries.
+  </Step>
+  <Step title="Update custom Blade components">
+    Replace `<x-shopper::buttons.*>` with the equivalent `<x-filament::button>` variants. Update any overridden modal components to their slide-over replacements.
+  </Step>
+  <Step title="Clear caches">
+    Run `php artisan optimize:clear`.
+  </Step>
+</Steps>

--- a/v2/upgrade/v2-2-to-v2-3.mdx
+++ b/v2/upgrade/v2-2-to-v2-3.mdx
@@ -93,10 +93,20 @@ If you have published product components via `php artisan shopper:component:publ
 
 ## Migration Checklist
 
-- [ ] Update `composer.json` dependencies
-- [ ] Run `composer update`
-- [ ] Run `php artisan migrate` (creates `product_tags` table)
-- [ ] Create new permissions for `tags`
-- [ ] Update published config files if applicable (`features.php`, `components/product.php`)
-- [ ] Clear caches: `php artisan optimize:clear`
-- [ ] Test your application
+<Steps>
+  <Step title="Update dependencies">
+    Update `shopper/framework` to `^2.3` in `composer.json`, then run `composer update -W`.
+  </Step>
+  <Step title="Run migrations">
+    Run `php artisan migrate` to create the `product_tags` table.
+  </Step>
+  <Step title="Create new permissions">
+    Run `Permission::generate('tags', 'products')` and assign the five generated permissions (`browse_tags`, `read_tags`, `edit_tags`, `add_tags`, `delete_tags`) to the `administrator` role.
+  </Step>
+  <Step title="Update published config files">
+    If you have published `config/shopper/features.php`, add the `tag` feature flag. If you have published `config/shopper/components/product.php`, add the `tag-index` component entry.
+  </Step>
+  <Step title="Clear caches">
+    Run `php artisan optimize:clear`.
+  </Step>
+</Steps>

--- a/v2/upgrade/v2-4-to-v2-5.mdx
+++ b/v2/upgrade/v2-4-to-v2-5.mdx
@@ -368,15 +368,32 @@ A new Shipments page in the admin panel provides a centralized view of all shipm
 
 ## Migration Checklist
 
-- [ ] Update `composer.json`: require `shopper/framework: ^2.5`
-- [ ] Run `composer update -W`
-- [ ] Run `php artisan migrate`
-- [ ] Replace removed `OrderStatus` values with `PaymentStatus` / `ShippingStatus` equivalents
-- [ ] Rename `$order->canceled_at` to `$order->cancelled_at`
-- [ ] Replace `$paymentMethod->logo` with `$paymentMethod->logoUrl()`
-- [ ] Replace `$carrier->logo` with `$carrier->logoUrl()`
-- [ ] If using a custom Order model: implement the new contract methods
-- [ ] If published order components: update `config/shopper/components/order.php` with new entries
-- [ ] Optional: `composer require shopper/stripe` for Stripe payments
-- [ ] Clear caches: `php artisan optimize:clear`
-- [ ] Test your application
+<Steps>
+  <Step title="Update dependencies">
+    Update `shopper/framework` to `^2.5` in `composer.json`, then run `composer update -W`.
+  </Step>
+  <Step title="Run migrations">
+    Run `php artisan migrate` to apply all new migrations, including the three-status order system and the media library columns for payment methods and carriers.
+  </Step>
+  <Step title="Replace removed OrderStatus values">
+    Replace all references to the removed `OrderStatus` values (`Pending`, `Registered`, `Paid`, `Shipped`, `Delivered`, `Returned`) with the equivalent `PaymentStatus` and `ShippingStatus` values.
+  </Step>
+  <Step title="Rename `canceled_at` to `cancelled_at`">
+    Update any code, queries, or Blade templates that reference `$order->canceled_at` to use `$order->cancelled_at`.
+  </Step>
+  <Step title="Replace logo property with `logoUrl()`">
+    Replace `$paymentMethod->logo` and `$carrier->logo` with `$paymentMethod->logoUrl()` and `$carrier->logoUrl()`. Re-upload existing logos through the admin panel if needed.
+  </Step>
+  <Step title="Update custom Order model">
+    If you use a custom Order model implementing `Shopper\Core\Models\Contracts\Order`, add the new contract methods (`isNew()`, `isPaid()`, `isShipped()`, etc.).
+  </Step>
+  <Step title="Update published order components">
+    If you have published `config/shopper/components/order.php`, add the new page and component entries for shipments, fulfillment, customer, items, notes, summary, and the two new slide-overs.
+  </Step>
+  <Step title="Install Stripe addon (optional)">
+    Run `composer require shopper/stripe` if you want Stripe payment support. See the [Stripe addon documentation](/v2/addons/stripe) for setup.
+  </Step>
+  <Step title="Clear caches">
+    Run `php artisan optimize:clear`.
+  </Step>
+</Steps>

--- a/v2/upgrade/v2-5-to-v2-6.mdx
+++ b/v2/upgrade/v2-5-to-v2-6.mdx
@@ -1,0 +1,255 @@
+---
+title: From v2.5 to v2.6
+description: How to upgrade your Shopper installation from v2.5 to v2.6.
+---
+
+<Info>
+**Estimated Upgrade Time:** 15–45 minutes depending on how much you customized auth models and event listeners.
+</Info>
+
+## Updating Dependencies
+
+Update your `composer.json` to require Shopper 2.6:
+
+```json
+"require": {
+    "shopper/framework": "^2.6"
+}
+```
+
+Then run:
+
+```bash
+composer update -W
+```
+
+After updating, run the migrations:
+
+```bash
+php artisan migrate
+```
+
+<Note>
+v2.6 ships one new package: `shopper/cart`. The tax system is built into `shopper/core`. Both are included in `shopper/framework` and installed automatically. Their migrations run with the standard `php artisan migrate` command.
+</Note>
+
+---
+
+## High Impact Changes
+
+### Auth Models and Traits Moved from Core to Admin
+
+**Likelihood of Impact: High**
+
+The `Role` and `Permission` models, the `ShopperUser` and `HasProfilePhoto` traits, and the `spatie/laravel-permission` dependency have all moved from `shopper/core` to `shopper/admin`.
+
+If you import any of these directly in your application code, update the namespaces:
+
+| Before (v2.5) | After (v2.6) |
+|---|---|
+| `Shopper\Core\Models\Role` | `Shopper\Models\Role` |
+| `Shopper\Core\Models\Permission` | `Shopper\Models\Permission` |
+| `Shopper\Core\Models\Contracts\ShopperUser` | `Shopper\Models\Contracts\ShopperUser` |
+| `Shopper\Core\Traits\ShopperUser` | `Shopper\Traits\InteractsWithShopper` |
+| `Shopper\Core\Models\Traits\HasProfilePhoto` | `Shopper\Traits\HasProfilePhoto` |
+
+The old namespaces are still present in `shopper/core` as deprecated aliases and will continue to work until v3.0, but you should migrate at your earliest convenience.
+
+The role configuration has also moved. If you referenced the admin role from `config/shopper/core.php`, update to `config/shopper/admin.php`:
+
+#### Before (v2.5)
+
+```php
+config('shopper.core.users.admin_role')
+```
+
+#### After (v2.6)
+
+```php
+config('shopper.admin.roles.admin')
+```
+
+---
+
+## Medium Impact Changes
+
+### New Migrations
+
+v2.6 adds 15 new migrations across two packages. Run `php artisan migrate` after updating.
+
+**Tax system (shopper/core):**
+
+| Migration | Description |
+|-----------|-------------|
+| `2026_02_24_000001_create_tax_providers_table` | Tax provider registry |
+| `2026_02_24_000002_create_tax_zones_table` | Geographic tax zones |
+| `2026_02_24_000003_create_tax_rates_table` | Rates and override rules |
+| `2026_02_25_000001_add_tax_amount_to_orders_table` | `tax_amount` column on orders |
+| `2026_02_25_000002_add_tax_columns_to_order_items_table` | `tax_amount` and `tax_rate_id` on order items |
+| `2026_02_25_000003_create_order_tax_lines_table` | Tax line snapshots |
+| `2026_02_25_000004_add_allow_backorder_to_products_table` | `allow_backorder` column on products |
+| `2026_02_25_000005_make_user_id_nullable_on_inventory_histories_table` | `user_id` becomes nullable |
+
+**Cart package (shopper/cart):**
+
+| Migration | Description |
+|-----------|-------------|
+| `2026_03_01_000001_create_carts_table` | Cart model |
+| `2026_03_01_000002_create_cart_lines_table` | Cart line items |
+| `2026_03_01_000003_create_cart_addresses_table` | Billing and shipping addresses |
+| `2026_03_01_000004_create_cart_line_adjustments_table` | Discount adjustments per line |
+| `2026_03_01_000005_create_cart_line_tax_lines_table` | Tax lines per cart line |
+
+**Performance (shopper/admin):**
+
+| Migration | Description |
+|-----------|-------------|
+| `2026_02_26_000001_add_status_indexes_to_orders_table` | Indexes on order status columns |
+
+### Order and Product Event Renaming
+
+**Likelihood of Impact: Medium**
+
+Two events have been renamed for consistency. If you registered listeners for either of these events, update your `EventServiceProvider`:
+
+| Before (v2.5) | After (v2.6) |
+|---|---|
+| `Shopper\Core\Events\Orders\OrderCancel` | `Shopper\Core\Events\Orders\OrderCancelled` |
+| `Shopper\Core\Events\Orders\AddNoteToOrder` | `Shopper\Core\Events\Orders\OrderNoteAdded` |
+
+#### Before (v2.5)
+
+```php
+use Shopper\Core\Events\Orders\OrderCancel;
+use Shopper\Core\Events\Orders\AddNoteToOrder;
+
+protected $listen = [
+    OrderCancel::class => [CancelOrderHandler::class],
+    AddNoteToOrder::class => [NotifyTeam::class],
+];
+```
+
+#### After (v2.6)
+
+```php
+use Shopper\Core\Events\Orders\OrderCancelled;
+use Shopper\Core\Events\Orders\OrderNoteAdded;
+
+protected $listen = [
+    OrderCancelled::class => [CancelOrderHandler::class],
+    OrderNoteAdded::class => [NotifyTeam::class],
+];
+```
+
+### Render Hooks — Enum Replaced by Scoped Classes
+
+**Likelihood of Impact: Medium**
+
+The `RenderHook` enum (`Shopper\Enum\RenderHook`) from v2.5 had 6 layout-level hooks. It has been replaced by seven scoped classes organized by business domain. If you used any of these hooks, update to `LayoutRenderHook`:
+
+| Before (v2.5) | After (v2.6) |
+|---|---|
+| `RenderHook::HeadStart` | `LayoutRenderHook::HEAD_START` |
+| `RenderHook::HeadEnd` | `LayoutRenderHook::HEAD_END` |
+| `RenderHook::BodyStart` | `LayoutRenderHook::BODY_START` |
+| `RenderHook::BodyEnd` | `LayoutRenderHook::BODY_END` |
+| `RenderHook::ContentStart` | `LayoutRenderHook::CONTENT_START` |
+| `RenderHook::ContentEnd` | `LayoutRenderHook::CONTENT_END` |
+
+The new classes are in the `Shopper\View` namespace. See the [Render Hooks](/v2/render-hooks) documentation for the complete list of available hooks across all 7 scoped classes.
+
+#### Before (v2.5)
+
+```php
+use Shopper\Enum\RenderHook;
+
+Shopper::renderHook(RenderHook::HeadEnd, fn () => '...');
+```
+
+#### After (v2.6)
+
+```php
+use Shopper\View\LayoutRenderHook;
+
+Shopper::renderHook(LayoutRenderHook::HEAD_END, fn () => '...');
+```
+
+---
+
+## Low Impact Changes
+
+### `allow_backorder` Column Added to Products
+
+A new boolean column `allow_backorder` has been added to the products table. It defaults to `false`. No action is required — the migration handles it automatically.
+
+When `allow_backorder` is `true` on a product or variant, the cart's `add()` and `update()` methods skip the stock availability check entirely, allowing the item to be added regardless of inventory level.
+
+### `user_id` Nullable on Inventory Histories
+
+The `user_id` foreign key on the `inventory_histories` table is now nullable. This accommodates stock changes triggered by automated processes rather than an admin action. No action is required.
+
+### Shopper Enums Now Implement `Shopper\Core\Contracts`
+
+Shopper's internal enums (`OrderStatus`, `ProductType`, etc.) now implement `HasLabel`, `HasIcon`, `HasColor`, and `HasDescription` from `Shopper\Core\Contracts` instead of `Filament\Support\Contracts`. This removes the Filament dependency from `shopper/core` and keeps the core package framework-agnostic.
+
+This has no impact on your application. Since Shopper runs on top of Filament, your own custom enums can continue to implement either `Filament\Support\Contracts` or `Shopper\Core\Contracts` — the method signatures are identical.
+
+---
+
+## New Features
+
+### Cart Package
+
+`shopper/cart` is now bundled with Shopper. It provides a full cart management system with pipeline-based calculation, discount validation, tax integration, and order conversion. See the [Cart documentation](/v2/cart) for setup and usage.
+
+### Tax System
+
+A built-in tax system is now available. Configure tax zones per country (or country + province), assign rates, and define override rules for specific products, product types, or categories. Taxes are calculated automatically in the cart pipeline. See the [Taxes documentation](/v2/taxes) for full details.
+
+### Dashboard Analytics
+
+The dashboard now includes five new Livewire components: a 12-month revenue bar chart, stat cards with month-over-month trends, a recent orders table, a top-selling products table, and an interactive setup guide. All data is cached with stale-while-revalidate semantics. See the [Dashboard documentation](/v2/dashboard).
+
+### Abandoned Carts
+
+A new admin page at **Orders → Abandoned Carts** lists carts that have been inactive for longer than the configured threshold (default: 60 minutes). The threshold is configurable in `config/shopper/cart.php`:
+
+```php
+'abandoned_after_minutes' => 60,
+```
+
+### Addon System
+
+Shopper now has a first-class addon API for packaging extensions. An addon can register routes, Livewire components, sidebar entries, views, settings items, and permissions as a single unit. See the [Addons documentation](/v2/addons).
+
+### Render Hooks
+
+62 named render hooks are now available across all admin pages. Use them to inject content into specific positions without modifying any Shopper views. See the [Render Hooks documentation](/v2/render-hooks).
+
+---
+
+## Migration Checklist
+
+<Steps>
+  <Step title="Update dependencies">
+    Run `composer update -W` after updating `shopper/framework` to `^2.6`.
+  </Step>
+  <Step title="Run migrations">
+    Run `php artisan migrate` to apply all 15 new migrations.
+  </Step>
+  <Step title="Update auth model namespaces">
+    Replace `Shopper\Core\Models\Role` → `Shopper\Models\Role` and `Shopper\Core\Models\Permission` → `Shopper\Models\Permission` wherever you import them.
+  </Step>
+  <Step title="Update auth trait namespaces">
+    Replace `Shopper\Core\Traits\ShopperUser` → `Shopper\Traits\InteractsWithShopper` and `Shopper\Core\Models\Traits\HasProfilePhoto` → `Shopper\Traits\HasProfilePhoto`.
+  </Step>
+  <Step title="Update renamed events">
+    Replace `OrderCancel` → `OrderCancelled` and `AddNoteToOrder` → `OrderNoteAdded` in your event listeners.
+  </Step>
+  <Step title="Update render hooks">
+    Replace the old `RenderHook` enum constants with the new scoped class constants if you used render hooks in v2.5.
+  </Step>
+  <Step title="Update role config key">
+    Replace `config('shopper.core.users.admin_role')` with `config('shopper.admin.roles.admin')` if you referenced it directly.
+  </Step>
+</Steps>

--- a/v2/upgrade/v2-5-to-v2-6.mdx
+++ b/v2/upgrade/v2-5-to-v2-6.mdx
@@ -188,6 +188,75 @@ When `allow_backorder` is `true` on a product or variant, the cart's `add()` and
 
 The `user_id` foreign key on the `inventory_histories` table is now nullable. This accommodates stock changes triggered by automated processes rather than an admin action. No action is required.
 
+### System Permissions Cleanup
+
+Three system permissions have been removed from the seeder and are no longer created on fresh installations:
+
+| Removed permission | Reason |
+|---|---|
+| `manage_mail` | No longer used by any component |
+| `impersonate` | No longer used by any component |
+| `setting_analytics` | No longer used by any component |
+
+For existing installations these permissions remain in your database but have no effect. You can delete them manually if you want to keep your permissions table clean:
+
+```php
+use Shopper\Models\Permission;
+
+Permission::query()->whereIn('name', ['manage_mail', 'impersonate', 'setting_analytics'])->delete();
+```
+
+### Server-Side Authorization Enforced Across Admin Components
+
+**Likelihood of Impact: Medium for custom roles**
+
+All admin Livewire pages and slide-overs now enforce permissions server-side via `$this->authorize()`. Previously, many components relied only on sidebar visibility to restrict access — a direct URL or Livewire call was enough to bypass the check.
+
+The following table lists every area that is now protected and the permission required:
+
+| Area | Permission |
+|---|---|
+| Settings pages (General, Carriers, Payment Methods, Taxes, Tax Zones, Legal) | `access_setting` |
+| Tax rate overrides slide-over | `access_setting` |
+| Shipping zone and rate slide-overs | `access_setting` |
+| Team management pages and slide-overs | `view_users` |
+| Product attributes slide-over | `edit_attributes` |
+| Product pricing slide-over | `edit_products` |
+| Choose product attributes slide-over | `edit_products` |
+| Related products slide-over | `edit_products` |
+| Generate variants slide-over | `edit_product_variants` |
+| Update variant slide-over | `edit_product_variants` |
+| Collection products and rules slide-overs | `edit_collections` |
+| Re-order categories slide-over | `edit_categories` |
+| Create shipping label slide-over | `edit_orders` |
+| Reviews index page and detail slide-over | `browse_reviews` |
+| Tags index page | `browse_tags` |
+
+The `administrator` role is not affected as it holds all permissions by default. For custom roles, assign the relevant permissions before upgrading:
+
+```php
+use Spatie\Permission\Models\Role;
+
+$role = Role::findByName('manager');
+
+$role->givePermissionTo([
+    'access_setting',
+    'view_users',
+    'edit_attributes',
+    'edit_products',
+    'edit_product_variants',
+    'edit_collections',
+    'edit_categories',
+    'edit_orders',
+    'browse_reviews',
+    'browse_tags',
+]);
+```
+
+<Warning>
+Review all custom roles in your installation and assign the permissions appropriate to their scope before upgrading. Users with insufficient permissions will receive a 403 response.
+</Warning>
+
 ### Shopper Enums Now Implement `Shopper\Core\Contracts`
 
 Shopper's internal enums (`OrderStatus`, `ProductType`, etc.) now implement `HasLabel`, `HasIcon`, `HasColor`, and `HasDescription` from `Shopper\Core\Contracts` instead of `Filament\Support\Contracts`. This removes the Filament dependency from `shopper/core` and keeps the core package framework-agnostic.
@@ -251,5 +320,8 @@ Shopper now has a first-class addon API for packaging extensions. An addon can r
   </Step>
   <Step title="Update role config key">
     Replace `config('shopper.core.users.admin_role')` with `config('shopper.admin.roles.admin')` if you referenced it directly.
+  </Step>
+  <Step title="Review custom role permissions">
+    Assign `access_setting`, `view_users`, `edit_attributes`, `edit_products`, `edit_product_variants`, `edit_collections`, `edit_categories`, `edit_orders`, `browse_reviews`, and `browse_tags` to any custom role that should access the corresponding areas. Optionally delete the unused `manage_mail`, `impersonate`, and `setting_analytics` permissions from your database.
   </Step>
 </Steps>


### PR DESCRIPTION
## Summary
- Add upgrade guide for v2.4 to v2.5
- Add cart and render hook documentation
- Add payment, shipping, and fulfillment documentation
- Add batch stock loading and `preventLazyStockLoading` documentation
- Add order detail components section to v2.5 upgrade guide
- Rename events documentation
- Add redirects for all v2-only routes to prevent 404s on unversioned URLs