### PR TITLE
docs: v2.10.0 release updates

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -240,6 +240,7 @@
                       "group": "Upgrade Guide",
                       "pages": [
                         "v2/upgrade",
+                        "v2/upgrade/v2-9-to-v2-10",
                         "v2/upgrade/v2-8-to-v2-9",
                         "v2/upgrade/v2-7-to-v2-8",
                         "v2/upgrade/v2-6-to-v2-7",

--- a/v2/cart.mdx
+++ b/v2/cart.mdx
@@ -380,7 +380,7 @@ When a coupon is applied during the pipeline, the `DiscountValidator` runs a ser
 | Usage limit | Total uses must be under the global limit | `discount.usage_limit_reached` |
 | Per-user limit | Customer must not have exceeded their per-user limit | `discount.already_used` |
 | Eligibility | If restricted to specific customers, the cart customer must be in the list | `discount.customer_not_eligible` |
-| Requires login | If eligibility is set, the cart must have a `customer_id` | `discount.requires_login` |
+| Requires login | If eligibility is set, or the discount has a per-user limit, the cart must have a `customer_id` | `discount.requires_login` |
 | Zone | If the discount has a `zone_id`, it must match `cart->zone_id` | `discount.not_available_in_zone` |
 | Minimum amount | Cart subtotal must meet the minimum purchase requirement | `discount.min_amount_not_reached` |
 | Minimum quantity | Total line quantity must meet the minimum quantity requirement | `discount.min_quantity_not_reached` |
@@ -416,7 +416,7 @@ The entire operation runs inside a database transaction with a `FOR UPDATE` lock
 2. **Calculates totals**. Runs the full pipeline to get final amounts
 3. **Creates order addresses**. Copies cart shipping/billing addresses to `OrderAddress` records
 4. **Creates the order**. With `price_amount`, `tax_amount`, `currency_code`, all foreign keys, and the discount snapshot (`discount_id`, `discount_code`, `discount_type`, `discount_value_at_apply`, `discount_currency_code`)
-5. **Creates order items**. One per cart line, including the discount amount from adjustments
+5. **Creates order items and reserves stock**. One order item per cart line, including the discount amount from adjustments. For every line whose purchasable tracks inventory, stock is reserved through the `StockReserver` contract under a `lockForUpdate` row lock on the stockable. If the reservable quantity is less than the line quantity, `InsufficientStockException` is thrown and the whole transaction rolls back
 6. **Creates order tax lines**. Via `CreateOrderTaxLinesAction`
 7. **Marks cart as completed**. Sets `completed_at` to prevent further modifications
 8. **Dispatches `CartCompleted` event**. With the cart and the created order
@@ -441,6 +441,32 @@ try {
 ```
 
 For the full enforcement model, see [Usage Limit Enforcement](/v2/discounts#usage-limit-enforcement) on the Discounts page.
+
+### Stock Reservation
+
+Stock is reserved during checkout, inside the same transaction that creates the order, rather than asynchronously after the order commits. This closes the oversell window where two concurrent checkouts could each read the same last unit and both succeed. Reservation is delegated to the `Shopper\Core\Contracts\StockReserver` contract:
+
+```php
+namespace Shopper\Core\Contracts;
+
+use Illuminate\Database\Eloquent\Model;
+use Shopper\Core\Models\Contracts\Stockable;
+
+interface StockReserver
+{
+    public function reserve(Stockable $product, int $quantity, ?Model $reference = null, ?int $userId = null): int;
+}
+```
+
+The default implementation, `LockingStockReserver`, takes a `lockForUpdate` row lock on the stockable, decrements the available quantity, and returns the amount actually reserved. The action throws `InsufficientStockException` when that amount is short of the requested quantity. Only purchasables that return `true` from `tracksInventory()` are reserved, so virtual and external products are skipped.
+
+To plug in a custom strategy, such as reserving against an external warehouse system, bind your own implementation in a service provider:
+
+```php
+use Shopper\Core\Contracts\StockReserver;
+
+$this->app->bind(StockReserver::class, WarehouseStockReserver::class);
+```
 
 ## Events
 

--- a/v2/discounts.mdx
+++ b/v2/discounts.mdx
@@ -213,6 +213,8 @@ Order::query()
 
 The same query runs in two places. `DiscountValidator` rejects the code at cart-apply time so the customer is not surprised at checkout. `CreateOrderFromCartAction` re-checks at commit and throws `DiscountLimitReachedException::perUser()` if the customer redeemed it between cart apply and commit.
 
+A per-user limit is meaningless without an identified customer, so a guest cart (no `customer_id`) can never apply a discount that sets `usage_limit_per_user`. Both `DiscountValidator` and `CreateOrderFromCartAction` reject it with the `discount.requires_login` error rather than letting a guest redeem a once-per-customer code on every anonymous checkout.
+
 ### Helpers
 
 ```php

--- a/v2/taxes.mdx
+++ b/v2/taxes.mdx
@@ -332,7 +332,7 @@ final class AvalaraTaxProvider implements TaxCalculationProvider
     public function getTaxLines(TaxableItem $item, TaxCalculationContext $context): array
     {
         $response = $this->client->calculate(
-            amount: $item->getTaxableAmount() * $item->getQuantity(),
+            amount: $item->getTaxableTotal(),
             countryCode: $context->countryCode,
             provinceCode: $context->provinceCode,
         );
@@ -390,15 +390,16 @@ Any object you pass to `TaxCalculator::calculate()` must implement `Shopper\Core
 
 | Method | Return | Description |
 |--------|--------|-------------|
-| `getTaxableAmount()` | `int` | Unit price in cents, after any item-level adjustments |
-| `getQuantity()` | `int` | Item quantity |
+| `getTaxableTotal()` | `int` | The full taxable line total in cents, after any item-level adjustments (unit price times quantity) |
 | `getProductType()` | `?string` | Product type value (`standard`, `virtual`, `external`) |
 | `getProductId()` | `?int` | The product's primary key |
 | `getCategoryIds()` | `array<int, int>` | Primary keys of all categories the product belongs to |
 
+The contract exposes a single `getTaxableTotal()` rather than a separate unit amount and quantity. The provider taxes that total in one pass, so a line whose total is not evenly divisible by its quantity is never rounded per unit. This keeps exclusive zones from overcharging by a cent and keeps inclusive VAT breakdowns balanced (net plus tax always equals gross).
+
 Shopper ships two ready-made adapters:
 
-- `CartLineTaxAdapter` wraps a `CartLine` for use during cart calculation; taxable amount is the post-discount line total divided by quantity
-- `OrderItemTaxAdapter` wraps an `OrderItem` for use in `CreateOrderTaxLinesAction`; taxable amount is the raw `unit_price_amount` in cents
+- `CartLineTaxAdapter` wraps a `CartLine` for use during cart calculation; the taxable total is the post-discount line total in cents
+- `OrderItemTaxAdapter` wraps an `OrderItem` for use in `CreateOrderTaxLinesAction`; the taxable total is `unit_price_amount` times `quantity` in cents
 
 If you are building a custom checkout flow or need to calculate taxes outside of a cart, you can implement `TaxableItem` directly on any of your objects and call `TaxCalculator::calculate()` with a manually constructed `TaxCalculationContext`.

--- a/v2/upgrade.mdx
+++ b/v2/upgrade.mdx
@@ -17,6 +17,7 @@ Before upgrading, take these precautions:
 
 | From | To | Summary |
 |------|-----|---------|
+| [v2.9](/v2/upgrade/v2-9-to-v2-10) | v2.10 | Security release: admin authorization audit, slide-over IDOR fix, exact tax on discounted totals (`TaxableItem` contract change), atomic stock reservation (`StockReserver` contract, `Stockable::tracksInventory()`), guest per-user discount block. No database migrations |
 | [v2.8](/v2/upgrade/v2-8-to-v2-9) | v2.9 | Laravel 13 support, onboarding wizard rebuilt on Filament Schema, cache stores scalars instead of models, Stripe SDK upgraded to v19. No database migrations |
 | [v2.7](/v2/upgrade/v2-7-to-v2-8) | v2.8 | Security release: authorization guards across admin Livewire components, atomic discount reservation, `orders` discount snapshot columns |
 | [v2.6](/v2/upgrade/v2-6-to-v2-7) | v2.7 | Money values stored in smallest currency unit (cents), slide-over components replaced, 2FA split into SOLID interfaces |

--- a/v2/upgrade/v2-9-to-v2-10.mdx
+++ b/v2/upgrade/v2-9-to-v2-10.mdx
@@ -1,0 +1,142 @@
+---
+title: From v2.9 to v2.10
+description: How to upgrade your Shopper installation from v2.9 to v2.10, a security and cart correctness release that changes three contracts.
+---
+
+<Info>
+**Estimated Upgrade Time:** 5 to 15 minutes. Most applications only need to update the dependency and clear the cache. The longer end applies if you implemented the `TaxableItem` contract, built a custom product model against `Stockable`, or registered the stock reservation listener yourself.
+</Info>
+
+v2.10 is a security and correctness release. It closes authorization gaps across the admin panel, fixes an IDOR on the pricing and variant slide-overs, taxes the discounted line total exactly, and reserves stock atomically during checkout. The breaking changes below only affect applications that extended the tax, stock, or checkout internals. Storefronts that consume Shopper through its public models and actions need no code changes. It contains no database migrations.
+
+## Updating Dependencies
+
+Update the following dependency in your application's `composer.json` file:
+
+`shopper/framework` to `^2.10`
+
+Then run:
+
+```bash
+composer update -W
+php artisan optimize:clear
+```
+
+## High Impact Changes
+
+### TaxableItem Contract Replaces Two Methods With One
+
+**Likelihood of Impact: High if you implemented `TaxableItem` directly.**
+*Affects applications with a custom tax adapter or a custom tax calculation provider that builds its own taxable items.*
+
+The `Shopper\Core\Contracts\TaxableItem` contract previously exposed the taxable amount as a unit price plus a quantity. Tax was then calculated per unit and multiplied back, which overcharged exclusive zones by a cent and unbalanced inclusive VAT breakdowns whenever a line total was not evenly divisible by its quantity. The contract now exposes a single line total and the provider taxes it in one pass.
+
+The `getTaxableAmount()` and `getQuantity()` methods are removed and replaced by `getTaxableTotal()`:
+
+```php
+// Before
+public function getTaxableAmount(): int { ... }
+public function getQuantity(): int { ... }
+
+// After
+public function getTaxableTotal(): int
+{
+    return $this->amount * $this->quantity;
+}
+```
+
+If you wrote a custom `TaxCalculationProvider` that read `$item->getTaxableAmount() * $item->getQuantity()`, replace that expression with `$item->getTaxableTotal()`. The built-in `CartLineTaxAdapter` and `OrderItemTaxAdapter` are already updated.
+
+### Stockable Contract Adds tracksInventory()
+
+**Likelihood of Impact: High if you swapped the product or variant model.**
+*Affects applications that bound a custom model against the `Product`, `ProductVariant`, or `Stockable` contract.*
+
+Stock reservation now skips products that do not track inventory, such as virtual and external products. To decide this, the `Shopper\Core\Models\Contracts\Stockable` contract gained a `tracksInventory(): bool` method. Because `Stockable` is the base of both the product and variant contracts, any custom model that implements one of them must add the method, or it will fail to satisfy the interface at runtime.
+
+Mirror the logic from the built-in `Product` model:
+
+```php
+public function tracksInventory(): bool
+{
+    return $this->isStandard() || $this->isVariant();
+}
+```
+
+If your model always carries inventory, return `true` unconditionally.
+
+## Medium Impact Changes
+
+### Stock Reservation Moved Into the Checkout Transaction
+
+**Likelihood of Impact: Medium**
+*Affects applications that registered the old reservation listener or instantiate `CreateOrderFromCartAction` manually.*
+
+Stock was previously reserved by a queued `ReserveOrderItemStockListener` that fired after the order transaction committed, with no row lock. Two concurrent checkouts reading the same last unit could both succeed and oversell. Reservation now happens synchronously inside `CreateOrderFromCartAction`, under a `lockForUpdate` row lock, through the new `Shopper\Core\Contracts\StockReserver` contract. If the available quantity falls short, `InsufficientStockException` is thrown and the whole order rolls back.
+
+The `Shopper\Core\Listeners\Orders\ReserveOrderItemStockListener` class is removed. If you registered it in your application's `EventServiceProvider`, drop that entry:
+
+```php
+// Remove any mapping like this from your $listen array:
+OrderItemCreated::class => [
+    ReserveOrderItemStockListener::class, // class no longer exists
+],
+```
+
+`CreateOrderFromCartAction` also gained a `StockReserver` constructor dependency. Always resolve it from the container so the dependency is injected for you, and never instantiate it with `new`:
+
+```php
+$order = resolve(CreateOrderFromCartAction::class)->execute($cart);
+```
+
+To customize reservation, for example against an external warehouse, bind your own implementation:
+
+```php
+use Shopper\Core\Contracts\StockReserver;
+
+$this->app->bind(StockReserver::class, WarehouseStockReserver::class);
+```
+
+### Guest Carts Cannot Apply Per-User Discounts
+
+**Likelihood of Impact: Medium**
+*Affects storefronts that let anonymous visitors apply coupons.*
+
+A coupon with `usage_limit_per_user` set was only checked when the cart had a `customer_id`, so a guest could redeem a once-per-customer code on every anonymous checkout. Both `DiscountValidator` and `CreateOrderFromCartAction` now reject these coupons for guest carts with the `discount.requires_login` error.
+
+If your storefront surfaces validation messages, handle this case by prompting the visitor to sign in before applying the coupon. Carts that already have an authenticated `customer_id` are unaffected.
+
+## Low Impact Changes
+
+### Admin Authorization Tightened
+
+**Likelihood of Impact: Low**
+*Affects applications with custom roles that granted coarse permissions.*
+
+A full audit added explicit `authorize()` calls to every mutating Filament action and Livewire method across the admin panel, and locked previously public model properties on the pricing and variant slide-overs. Standard role setups are unaffected. If you built custom roles that relied on a coarse permission to reach a finer operation, for example granting `add_products` to manage variants, grant the specific permission instead, such as `add_product_variants`.
+
+## Migration Checklist
+
+<Steps>
+  <Step title="Update composer">
+    Set `shopper/framework` to `^2.10` and run `composer update -W`.
+  </Step>
+  <Step title="Update TaxableItem implementers">
+    Replace `getTaxableAmount()` and `getQuantity()` with `getTaxableTotal()` on any class that implements `TaxableItem`.
+  </Step>
+  <Step title="Add tracksInventory() to custom models">
+    If you swapped the product or variant model, add `tracksInventory(): bool` to satisfy the `Stockable` contract.
+  </Step>
+  <Step title="Remove the old reservation listener">
+    Drop any reference to `ReserveOrderItemStockListener` from your `EventServiceProvider`.
+  </Step>
+  <Step title="Resolve checkout action from the container">
+    Replace any `new CreateOrderFromCartAction(...)` with `resolve(CreateOrderFromCartAction::class)`.
+  </Step>
+  <Step title="Review guest coupon flows">
+    If anonymous visitors can apply coupons, handle the `discount.requires_login` error for per-user discounts.
+  </Step>
+  <Step title="Run tests">
+    Run `php artisan test` to confirm the upgrade is clean.
+  </Step>
+</Steps>


### PR DESCRIPTION
Syncs the documentation with the v2.10.0 code changes and adds the upgrade guide.

## Updated pages

- **`v2/taxes.mdx`** — The `TaxableItem` contract now exposes a single `getTaxableTotal()` instead of `getTaxableAmount()` plus `getQuantity()`. Updated the method table, the custom provider example, and the adapter descriptions.
- **`v2/cart.mdx`** — The checkout flow now reserves stock atomically inside the order transaction. Added the reservation step to "What Happens", a new **Stock Reservation** section documenting the `StockReserver` contract and how to swap it, and updated the discount validation rule for per-user limits.
- **`v2/discounts.mdx`** — Documented that a guest cart cannot apply a discount with a per-user limit (returns `discount.requires_login`).

## New page

- **`v2/upgrade/v2-9-to-v2-10.mdx`** — Upgrade guide covering the four breaking changes (`TaxableItem`, `Stockable::tracksInventory()`, removed `ReserveOrderItemStockListener`, `CreateOrderFromCartAction` constructor) with a migration checklist.

## Navigation

- Added the upgrade guide to `docs.json` and the index table in `v2/upgrade.mdx`.

All examples verified against the v2.10.0 source (contracts, adapters, and `CreateOrderFromCartAction`).
