### PR TITLE
docs: document upload mime allowlist and team management safeguards

### DIFF
--- a/v2/acl.mdx
+++ b/v2/acl.mdx
@@ -92,6 +92,18 @@ The `system` group contains the global capabilities that gate everything outside
 Since v2.8, `access_setting` is the only permission that grants write access to PaymentMethods, Currencies, Carriers, Team management, and Role/Permission management. Roles that previously relied on `view_users` to mutate these surfaces must be granted `access_setting` to keep working.
 </Note>
 
+### Team Management Safeguards
+
+Holding `access_setting` grants access to the team settings surfaces, but since v2.11.2 it no longer grants unrestricted control over the access control system itself. Without these safeguards, granting `access_setting` to a staff member so they could configure shipping or taxes also handed them a path to full administrator capability. Non administrator users are now subject to three rules:
+
+| Rule | Effect |
+|------|--------|
+| The administrator role cannot be targeted | A non administrator cannot open, update, delete the administrator role, or assign it to a new team member |
+| A permission can only be granted if the acting user holds it | A staff member cannot give a role a capability they do not have themselves |
+| Permission definitions are administrator only | Creating or deleting a permission requires the administrator role |
+
+Administrators are unaffected: they hold every permission, so every rule short circuits for them. Permissions and roles flagged with `can_be_removed` set to `false` are also protected on the server, not only hidden in the UI.
+
 ### Generating Permissions
 
 The `Permission::generate()` method creates five permissions for a given resource (browse, read, edit, add, delete):

--- a/v2/media.mdx
+++ b/v2/media.mdx
@@ -30,11 +30,18 @@ Lists the MIME types allowed for media files. This ensures that only specified f
 
 ```php "config/shopper/media.php"
 'accepts_mime_types' => [
-    'image/jpg',
     'image/jpeg',
     'image/png',
+    'image/webp',
+    'image/avif',
 ]
 ```
+
+Since v2.11.2, this allowlist governs every image upload in the admin panel: media collections on products, variants, brands, collections and categories, and also the account avatar and the store logo and cover in the settings. Before v2.11.2, those three settings fields accepted any `image/*` type regardless of this configuration.
+
+<Warning>
+SVG is deliberately excluded from the default list. An SVG file can embed scripts that execute when the file is opened from your storage URL, which allows a staff account to attack an administrator session. Only add `image/svg+xml` back if you understand and accept that risk.
+</Warning>
 
 ### Media Filesize
 

--- a/v2/user-guide/administration/roles.mdx
+++ b/v2/user-guide/administration/roles.mdx
@@ -85,6 +85,10 @@ Add custom permissions for your specific needs:
   <img src="/images/v2/add-permission.png" alt="Add Permission" />
 </Frame>
 
+<Note>
+Creating or deleting a permission requires an **Administrator** account. Other staff members can still grant existing permissions to roles, but only permissions they hold themselves, and they cannot modify the Administrator role.
+</Note>
+
 ## Custom Permissions
 
 Create permissions tailored to your business:

--- a/v2/user-guide/administration/users.mdx
+++ b/v2/user-guide/administration/users.mdx
@@ -47,6 +47,10 @@ To add a new staff member:
 | **Role** | Yes | Permission level for this user |
 | **Send invite** | No | Email login credentials |
 
+<Note>
+Only administrators can assign the **Administrator** role to a new team member. For other staff members, this role does not appear in the role choices.
+</Note>
+
 ## Staff Roles
 
 Each staff member is assigned a role that determines what they can access:


### PR DESCRIPTION
## What changed

Documents the behaviour introduced by the latest 2.x security fixes (shopperlabs/shopper#653 and shopperlabs/shopper#654).

- `v2/media.mdx`: the documented `accepts_mime_types` default was outdated (jpg/jpeg/png), replaced with the actual config values (jpeg/png/webp/avif). Notes that the allowlist now also governs the account avatar and the store logo and cover uploads, with a warning about re-enabling SVG.
- `v2/acl.mdx`: new Team Management Safeguards section explaining the three authorization rules applied to non administrators (administrator role cannot be targeted, permissions can only be granted by users who hold them, permission definitions are administrator only) and the server side `can_be_removed` enforcement.
- `v2/user-guide/administration/roles.mdx`: note that creating or deleting permissions requires an Administrator account.
- `v2/user-guide/administration/users.mdx`: note that only administrators can assign the Administrator role to a new team member.